### PR TITLE
build: remove seanmiddleditch/gha-setup-ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,11 @@ jobs:
         uses: carlosperate/arm-none-eabi-gcc-action@48db4484a55750df7a0ccca63347fcdea6534d78 # v1.6.0
         with:
           release: ${{ matrix.gcc }}
-      - uses: seanmiddleditch/gha-setup-ninja@16b940825621068d98711680b6c3ff92201f8fc0
       - uses: hendrikmuhs/ccache-action@fba817f3c0db4f854d7a3ee688241d6754da166e # v1.2.8
         with:
           key: ${{ matrix.gcc }}-${{ matrix.configuration }}
       - run: |
-          sudo apt-get update && sudo apt-get install --no-install-recommends -y xsltproc
+          sudo apt-get update && sudo apt-get install --no-install-recommends ninja-build xsltproc
           echo "::add-matcher::.github/matchers/gcc-problem-matcher.json"
           cmake --preset host -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build --preset host-${{ matrix.configuration }}


### PR DESCRIPTION
The seanmiddleditch/gha-setup-ninja action has not yet moved from node12 to node16 as is recommended by GitHub (https://github.com/seanmiddleditch/gha-setup-ninja/issues/16). This gives unnecessary warnings in our build summaries.

Replace the usage of the action by installing ninja via the package manager.