### PR TITLE
build: refactor CMakeLists files to use emil_build_for

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,7 @@ endif()
 add_subdirectory(st)
 add_subdirectory(hal_st)
 add_subdirectory(hal_st_lwip)
-
-if (HALST_BUILD_EXAMPLES)
-    add_subdirectory(examples)
-endif()
+add_subdirectory(examples)
 
 emil_clangformat_directories(hal_st DIRECTORIES .)
 

--- a/examples/blink/CMakeLists.txt
+++ b/examples/blink/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(hal_st.blink_nucleo144 Main.cpp)
-emil_build_for(hal_st.blink_nucleo144 PREREQUISITE_BOOL HALST_BUILD_EXAMPLES)
+emil_build_for(hal_st.blink_nucleo144 BOOL HALST_BUILD_EXAMPLES)
 set_target_properties(hal_st.blink_nucleo144 PROPERTIES EXCLUDE_FROM_ALL $<NOT:$<STREQUAL:${TARGET_MCU_VENDOR},st>>)
 
 target_compile_definitions(hal_st.blink_nucleo144 PUBLIC
@@ -19,7 +19,7 @@ emil_generate_artifacts(TARGET hal_st.blink_nucleo144 LST MAP BIN HEX)
 ######################################################################
 
 add_executable(hal_st.blink_nucleo64 Main.cpp)
-emil_build_for(hal_st.blink_nucleo64 PREREQUISITE_BOOL HALST_BUILD_EXAMPLES)
+emil_build_for(hal_st.blink_nucleo64 BOOL HALST_BUILD_EXAMPLES)
 set_target_properties(hal_st.blink_nucleo64 PROPERTIES EXCLUDE_FROM_ALL $<NOT:$<STREQUAL:${TARGET_MCU_VENDOR},st>>)
 
 target_compile_definitions(hal_st.blink_nucleo64 PUBLIC

--- a/examples/blink/CMakeLists.txt
+++ b/examples/blink/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(hal_st.blink_nucleo144 Main.cpp)
+emil_build_for(hal_st.blink_nucleo144 PREREQUISITE_BOOL HALST_BUILD_EXAMPLES)
 set_target_properties(hal_st.blink_nucleo144 PROPERTIES EXCLUDE_FROM_ALL $<NOT:$<STREQUAL:${TARGET_MCU_VENDOR},st>>)
 
 target_compile_definitions(hal_st.blink_nucleo144 PUBLIC
@@ -18,6 +19,7 @@ emil_generate_artifacts(TARGET hal_st.blink_nucleo144 LST MAP BIN HEX)
 ######################################################################
 
 add_executable(hal_st.blink_nucleo64 Main.cpp)
+emil_build_for(hal_st.blink_nucleo64 PREREQUISITE_BOOL HALST_BUILD_EXAMPLES)
 set_target_properties(hal_st.blink_nucleo64 PROPERTIES EXCLUDE_FROM_ALL $<NOT:$<STREQUAL:${TARGET_MCU_VENDOR},st>>)
 
 target_compile_definitions(hal_st.blink_nucleo64 PUBLIC

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -1,15 +1,13 @@
-if (${HALST_BUILD_EXAMPLES_FREERTOS})
-    add_executable(hal_st.freertos_nucleo144 Main.cpp)
-    emil_build_for(hal_st.freertos_nucleo144 TARGET_MCU_VENDOR st)
+add_executable(hal_st.freertos_nucleo144 Main.cpp)
+emil_build_for(hal_st.freertos_nucleo144 TARGET_MCU_VENDOR st PREREQUISITE_BOOL HALST_BUILD_EXAMPLES_FREERTOS)
 
-    target_link_libraries(hal_st.freertos_nucleo144 PRIVATE
-        hal_st.instantiations
-        osal.thread
-        osal.freertos_system_time
-    )
+target_link_libraries(hal_st.freertos_nucleo144 PRIVATE
+    hal_st.instantiations
+    osal.thread
+    osal.freertos_system_time
+)
 
-    halst_target_default_linker_scripts(hal_st.freertos_nucleo144)
-    halst_target_default_init(hal_st.freertos_nucleo144)
+halst_target_default_linker_scripts(hal_st.freertos_nucleo144)
+halst_target_default_init(hal_st.freertos_nucleo144)
 
-    emil_generate_artifacts(TARGET hal_st.freertos_nucleo144 LST MAP BIN HEX)
-endif()
+emil_generate_artifacts(TARGET hal_st.freertos_nucleo144 LST MAP BIN HEX)

--- a/hal_st/middlewares/STM32_WPAN/CMakeLists.txt
+++ b/hal_st/middlewares/STM32_WPAN/CMakeLists.txt
@@ -1,58 +1,55 @@
-if ("${TARGET_MCU_VENDOR}" STREQUAL st AND "${TARGET_MCU_FAMILY}" STREQUAL stm32wbxx)
+add_library(hal_st.stm32_wpan STATIC)
+emil_build_for(hal_st.stm32_wpan TARGET_MCU_FAMILY stm32wbxx PREREQUISITE_BOOL HALST_STANDALONE)
+install(TARGETS hal_st.stm32_wpan EXPORT halStTargets)
 
-    add_library(hal_st.stm32_wpan ${HALST_EXCLUDE_FROM_ALL} STATIC)
-    install(TARGETS hal_st.stm32_wpan EXPORT halStTargets)
+target_include_directories(hal_st.stm32_wpan PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/app_specific>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core/auto>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core/template>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread/shci>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread/tl>"
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/utilities>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
-    target_include_directories(hal_st.stm32_wpan PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/app_specific>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core/auto>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/ble/core/template>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread/shci>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/interface/patterns/ble_thread/tl>"
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/utilities>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    )
+target_link_libraries(hal_st.stm32_wpan PUBLIC
+    st.hal_driver
+)
 
-    target_link_libraries(hal_st.stm32_wpan PUBLIC
-        st.hal_driver
-    )
+target_sources(hal_st.stm32_wpan PRIVATE
+    ble/core/auto/ble_gap_aci.c
+    ble/core/auto/ble_gap_aci.h
+    ble/core/auto/ble_gatt_aci.c
+    ble/core/auto/ble_gatt_aci.h
+    ble/core/auto/ble_hal_aci.c
+    ble/core/auto/ble_hal_aci.h
+    ble/core/auto/ble_hci_le.c
+    ble/core/auto/ble_hci_le.h
+    ble/core/auto/ble_l2cap_aci.c
+    ble/core/auto/ble_l2cap_aci.h
+    ble/core/template/osal.c
+    ble/core/template/osal.h
+    ble/svc/Src/bls.c
+    ble/svc/Src/svc_ctl.c
+    interface/patterns/ble_thread/shci/shci.c
+    interface/patterns/ble_thread/shci/shci.h
+    interface/patterns/ble_thread/tl/hci_tl.c
+    interface/patterns/ble_thread/tl/hci_tl.h
+    interface/patterns/ble_thread/tl/hci_tl_if.c
+    interface/patterns/ble_thread/tl/shci_tl.c
+    interface/patterns/ble_thread/tl/shci_tl.h
+    interface/patterns/ble_thread/tl/shci_tl_if.c
+    interface/patterns/ble_thread/tl/tl_mbox.c
+    interface/patterns/ble_thread/tl/tl.h
 
-    target_sources(hal_st.stm32_wpan PRIVATE
-        ble/core/auto/ble_gap_aci.c
-        ble/core/auto/ble_gap_aci.h
-        ble/core/auto/ble_gatt_aci.c
-        ble/core/auto/ble_gatt_aci.h
-        ble/core/auto/ble_hal_aci.c
-        ble/core/auto/ble_hal_aci.h
-        ble/core/auto/ble_hci_le.c
-        ble/core/auto/ble_hci_le.h
-        ble/core/auto/ble_l2cap_aci.c
-        ble/core/auto/ble_l2cap_aci.h
-        ble/core/template/osal.c
-        ble/core/template/osal.h
-        ble/svc/Src/bls.c
-        ble/svc/Src/svc_ctl.c
-        interface/patterns/ble_thread/shci/shci.c
-        interface/patterns/ble_thread/shci/shci.h
-        interface/patterns/ble_thread/tl/hci_tl.c
-        interface/patterns/ble_thread/tl/hci_tl.h
-        interface/patterns/ble_thread/tl/hci_tl_if.c
-        interface/patterns/ble_thread/tl/shci_tl.c
-        interface/patterns/ble_thread/tl/shci_tl.h
-        interface/patterns/ble_thread/tl/shci_tl_if.c
-        interface/patterns/ble_thread/tl/tl_mbox.c
-        interface/patterns/ble_thread/tl/tl.h
-
-        #Init workaround
-        utilities/otp.c
-        utilities/stm_list.c
-        utilities/dbg_trace.c
-        utilities/stm_queue.c
-        app_specific/target/hw_ipcc.c
-    )
-
-endif()
+    #Init workaround
+    utilities/otp.c
+    utilities/stm_list.c
+    utilities/dbg_trace.c
+    utilities/stm_queue.c
+    app_specific/target/hw_ipcc.c
+)

--- a/hal_st/middlewares/ble_middleware/CMakeLists.txt
+++ b/hal_st/middlewares/ble_middleware/CMakeLists.txt
@@ -1,42 +1,39 @@
-if ("${TARGET_MCU_VENDOR}" STREQUAL st AND "${TARGET_MCU_FAMILY}" STREQUAL stm32wbxx)
+add_library(hal_st.ble_middleware STATIC)
+emil_build_for(hal_st.ble_middleware TARGET_MCU_FAMILY stm32wbxx PREREQUISITE_BOOL HALST_STANDALONE)
+install(TARGETS hal_st.ble_middleware EXPORT halStTargets)
 
-    add_library(hal_st.ble_middleware ${HALST_EXCLUDE_FROM_ALL} STATIC)
-    install(TARGETS hal_st.ble_middleware EXPORT halStTargets)
+target_include_directories(hal_st.ble_middleware PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../..>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 
-    target_include_directories(hal_st.ble_middleware PUBLIC
-        "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../../..>"
-        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    )
+target_link_libraries(hal_st.ble_middleware PUBLIC
+    hal_st.stm32_wpan
+    services.ble
+    services.util
+    services.tracer
+)
 
-    target_link_libraries(hal_st.ble_middleware PUBLIC
-        hal_st.stm32_wpan
-        services.ble
-        services.util
-        services.tracer
-    )
-
-    target_sources(hal_st.ble_middleware PRIVATE
-        BondStorageSt.cpp
-        BondStorageSt.hpp
-        GapCentralSt.cpp
-        GapCentralSt.hpp
-        GapPeripheralSt.cpp
-        GapPeripheralSt.hpp
-        GapSt.cpp
-        GapSt.hpp
-        GattServerSt.cpp
-        GattServerSt.hpp
-        HciEventObserver.hpp
-        SystemTransportLayer.cpp
-        SystemTransportLayer.hpp
-        TracingGapCentralSt.cpp
-        TracingGapCentralSt.hpp
-        TracingGapPeripheralSt.cpp
-        TracingGapPeripheralSt.hpp
-        TracingGattServerSt.cpp
-        TracingGattServerSt.hpp
-        TracingSystemTransportLayer.cpp
-        TracingSystemTransportLayer.hpp
-    )
-
-endif()
+target_sources(hal_st.ble_middleware PRIVATE
+    BondStorageSt.cpp
+    BondStorageSt.hpp
+    GapCentralSt.cpp
+    GapCentralSt.hpp
+    GapPeripheralSt.cpp
+    GapPeripheralSt.hpp
+    GapSt.cpp
+    GapSt.hpp
+    GattServerSt.cpp
+    GattServerSt.hpp
+    HciEventObserver.hpp
+    SystemTransportLayer.cpp
+    SystemTransportLayer.hpp
+    TracingGapCentralSt.cpp
+    TracingGapCentralSt.hpp
+    TracingGapPeripheralSt.cpp
+    TracingGapPeripheralSt.hpp
+    TracingGattServerSt.cpp
+    TracingGattServerSt.hpp
+    TracingSystemTransportLayer.cpp
+    TracingSystemTransportLayer.hpp
+)


### PR DESCRIPTION
build: refactor CMakeLists files to use emil_build_for instead of conditionally adding targets