### PR TITLE
fix GetAdvertisementData and GetScanResponseData in GapPeripheralSt

### DIFF
--- a/.github/workflows/linting-formatting.yml
+++ b/.github/workflows/linting-formatting.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
-      #- uses: DoozyX/clang-format-lint-action@c3b2c943e924028b93a707a5b1b017976ab8d50c
+      #- uses: DoozyX/clang-format-lint-action@a83a8fb7d371f66da7dd1c4f33a193023899494b # v0.16
       #  with:
       #    clangFormatVersion: 14
       #    inplace: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        9856f2304b818f69926db810aabadbd2c1a82659 # Unreleased
+        GIT_TAG        77eb4170285a16e31cae5aee6a96e792baea2aa7 # Unreleased
     )
 
     FetchContent_MakeAvailable(emil)

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -74,9 +74,9 @@ namespace hal
         advertisementData.assign(data);
     }
 
-    infra::ConstByteRange GapPeripheralSt::GetAdvertisementData()
+    infra::ConstByteRange GapPeripheralSt::GetAdvertisementData() const
     {
-        return infra::MakeConstByteRange(advertisementData);
+        return infra::MakeRange(advertisementData);
     }
 
     void GapPeripheralSt::SetScanResponseData(infra::ConstByteRange data)
@@ -84,9 +84,9 @@ namespace hal
         scanResponseData.assign(data);
     }
 
-    infra::ConstByteRange GapPeripheralSt::GetScanResponseData()
+    infra::ConstByteRange GapPeripheralSt::GetScanResponseData() const
     {
-        return infra::MakeConstByteRange(scanResponseData);
+        return infra::MakeRange(scanResponseData);
     }
 
     void GapPeripheralSt::UpdateAdvertisementData()

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.hpp
@@ -29,9 +29,9 @@ namespace hal
         virtual services::GapAddress GetAddress() const override;
         virtual services::GapAddress GetIdentityAddress() const override;
         virtual void SetAdvertisementData(infra::ConstByteRange data) override;
-        virtual infra::ConstByteRange GetAdvertisementData() override;
+        virtual infra::ConstByteRange GetAdvertisementData() const override;
         virtual void SetScanResponseData(infra::ConstByteRange data) override;
-        virtual infra::ConstByteRange GetScanResponseData() override;
+        virtual infra::ConstByteRange GetScanResponseData() const override;
         virtual void Advertise(services::GapAdvertisementType type, AdvertisementIntervalMultiplier multiplier) override;
         virtual void Standby() override;
 


### PR DESCRIPTION
Fix to return ConstByteRange that only contains data instead of the entire data structure of advertisementData and scanresponseData (infra::BoundedVector). 