### PR TITLE
fix: incorrect connection handle in state transitions

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -103,13 +103,6 @@ namespace hal
     {
         GapSt::HandleHciDisconnectEvent(eventPacket);
 
-        auto disconnectionCompleteEvent = *reinterpret_cast<hci_disconnection_complete_event_rp0*>(eventPacket.data);
-
-        really_assert(disconnectionCompleteEvent.Connection_Handle == connectionContext.connectionHandle);
-        really_assert(disconnectionCompleteEvent.Status == BLE_STATUS_SUCCESS);
-
-        connectionContext.connectionHandle = GapSt::invalidConnection;
-
         infra::Subject<services::GapCentralObserver>::NotifyObservers([](auto& observer) { observer.StateChanged(services::GapState::standby); });
     }
 

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -128,11 +128,13 @@ namespace hal
 
     void GapPeripheralSt::Standby()
     {
-        if (connectionContext.connectionHandle != 0)
+        if (connectionContext.connectionHandle != GapSt::invalidConnection)
             aci_gap_terminate(connectionContext.connectionHandle, 0x13);
-
-        aci_gap_set_non_discoverable();
-        UpdateState(services::GapState::standby);
+        else
+        {
+            aci_gap_set_non_discoverable();
+            UpdateState(services::GapState::standby);
+        }
     }
 
     void GapPeripheralSt::AllowPairing(bool allow)
@@ -230,15 +232,7 @@ namespace hal
     void GapPeripheralSt::HandleHciDisconnectEvent(hci_event_pckt& eventPacket)
     {
         GapSt::HandleHciDisconnectEvent(eventPacket);
-
-        auto disconnectEvt = reinterpret_cast<hci_disconnection_complete_event_rp0*>(eventPacket.data);
-
-        if (disconnectEvt->Connection_Handle == connectionContext.connectionHandle)
-        {
-            connectionContext.connectionHandle = 0;
-
-            UpdateState(services::GapState::standby);
-        }
+        UpdateState(services::GapState::standby);
     }
 
     void GapPeripheralSt::HandleHciLeEnhancedConnectionCompleteEvent(evt_le_meta_event* metaEvent)

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -130,11 +130,9 @@ namespace hal
     {
         if (connectionContext.connectionHandle != 0)
             aci_gap_terminate(connectionContext.connectionHandle, 0x13);
-        else
-        {
-            aci_gap_set_non_discoverable();
-            UpdateState(services::GapState::standby);
-        }
+
+        aci_gap_set_non_discoverable();
+        UpdateState(services::GapState::standby);
     }
 
     void GapPeripheralSt::AllowPairing(bool allow)

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -102,6 +102,16 @@ namespace hal
         return maxAttMtu;
     }
 
+    void GapSt::HandleHciDisconnectEvent(hci_event_pckt& eventPacket)
+    {
+        auto disconnectionCompleteEvent = *reinterpret_cast<hci_disconnection_complete_event_rp0*>(eventPacket.data);
+
+        really_assert(disconnectionCompleteEvent.Connection_Handle == connectionContext.connectionHandle);
+        really_assert(disconnectionCompleteEvent.Status == BLE_STATUS_SUCCESS);
+
+        connectionContext.connectionHandle = GapSt::invalidConnection;
+    }
+
     void GapSt::HandleHciLeConnectionCompleteEvent(evt_le_meta_event* metaEvent)
     {
         auto connectionCompleteEvent = *reinterpret_cast<hci_le_connection_complete_event_rp0*>(metaEvent->data);

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -37,7 +37,7 @@ namespace hal
         // Implementation of AttMtuExchange
         virtual uint16_t EffectiveMaxAttMtuSize() const override;
 
-        virtual void HandleHciDisconnectEvent(hci_event_pckt& eventPacket) {};
+        virtual void HandleHciDisconnectEvent(hci_event_pckt& eventPacket);
 
         virtual void HandleHciLeConnectionCompleteEvent(evt_le_meta_event* metaEvent);
         virtual void HandleHciLeAdvertisingReportEvent(evt_le_meta_event* metaEvent) {};


### PR DESCRIPTION
A requested transition from Standby to Advertise to Standby from the product would stay in Advertise state