### PR TITLE
fix: add confirmation for gatt indication

### DIFF
--- a/hal_st/middlewares/ble_middleware/GattServerSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattServerSt.cpp
@@ -134,4 +134,22 @@ namespace hal
 
     void GattServerSt::ReportError(tBleStatus status) const
     {}
+
+    GattConfirmIndication::GattConfirmIndication(hal::HciEventSource& hciEventSource)
+        : hal::HciEventSink(hciEventSource)
+    {}
+
+    void GattConfirmIndication::HciEvent(hci_event_pckt& event)
+    {
+        if (event.evt == HCI_VENDOR_SPECIFIC_DEBUG_EVT_CODE)
+        {
+            const auto vendorEvent = reinterpret_cast<evt_blecore_aci*>(event.data);
+            if (vendorEvent->ecode == ACI_GATT_INDICATION_VSEVT_CODE)
+            {
+                const auto gattIndicationEvent = *reinterpret_cast<aci_gatt_indication_event_rp0*>(vendorEvent->data);
+                
+                aci_gatt_confirm_indication(gattIndicationEvent.Connection_Handle);
+            }
+        }
+    }
 }

--- a/hal_st/middlewares/ble_middleware/GattServerSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattServerSt.cpp
@@ -147,7 +147,6 @@ namespace hal
             if (vendorEvent->ecode == ACI_GATT_INDICATION_VSEVT_CODE)
             {
                 const auto gattIndicationEvent = *reinterpret_cast<aci_gatt_indication_event_rp0*>(vendorEvent->data);
-                
                 aci_gatt_confirm_indication(gattIndicationEvent.Connection_Handle);
             }
         }

--- a/hal_st/middlewares/ble_middleware/GattServerSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattServerSt.hpp
@@ -36,11 +36,11 @@ namespace hal
     class GattConfirmIndication
         : public hal::HciEventSink
     {
-        public:
-            explicit GattConfirmIndication(hal::HciEventSource& hciEventSource);
+    public:
+        explicit GattConfirmIndication(hal::HciEventSource& hciEventSource);
 
-            // Implementation of hal::HciEventSink
-            void HciEvent(hci_event_pckt& event) override;
+        // Implementation of hal::HciEventSink
+        void HciEvent(hci_event_pckt& event) override;
     };
 }
 

--- a/hal_st/middlewares/ble_middleware/GattServerSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattServerSt.hpp
@@ -32,6 +32,16 @@ namespace hal
     private:
         infra::IntrusiveForwardList<services::GattServerService> services;
     };
+
+    class GattConfirmIndication
+        : public hal::HciEventSink
+    {
+        public:
+            explicit GattConfirmIndication(hal::HciEventSource& hciEventSource);
+
+            // Implementation of hal::HciEventSink
+            void HciEvent(hci_event_pckt& event) override;
+    };
 }
 
 #endif


### PR DESCRIPTION
An anomaly from GATT client is observed with few mobile phone where GATT server changed indication sent to GATT server even if not subscribed. If the indication is not confirmed then it results in GATT procedure timeout. Added confirm indication to avoid GATT procedure timeout.