### PR TITLE
chore: Make abort a weak definition

### DIFF
--- a/hal_st/default_init/DefaultInit.cpp
+++ b/hal_st/default_init/DefaultInit.cpp
@@ -37,7 +37,7 @@ extern "C"
         hal::InterruptTable::Instance().Invoke(hal::ActiveInterrupt());
     }
 
-    void abort()
+    [[gnu::weak]] void abort()
     {
         __BKPT();
         HAL_NVIC_SystemReset();


### PR DESCRIPTION
Weak makes it possible to override which is useful for library integration in different contexts.