### PR TITLE
feat: add uart pin swap configuration option when supported

### DIFF
--- a/hal_st/stm32fxxx/UartStm.cpp
+++ b/hal_st/stm32fxxx/UartStm.cpp
@@ -70,6 +70,18 @@ namespace hal
         uartHandle.Init.OverSampling = UART_OVERSAMPLING_8;
 #endif
 
+#if defined(UART_ADVFEATURE_NO_INIT)
+        uartHandle.AdvancedInit = {};
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+        if (config.swapTxRx)
+        {
+            uartHandle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_SWAP_INIT;
+            uartHandle.AdvancedInit.Swap = UART_ADVFEATURE_SWAP_ENABLE;
+        }
+#endif
+#endif
+
         HAL_UART_Init(&uartHandle);
 
 #if defined(STM32WB)

--- a/hal_st/stm32fxxx/UartStm.hpp
+++ b/hal_st/stm32fxxx/UartStm.hpp
@@ -22,6 +22,10 @@ namespace hal
             uint32_t baudrate{ 115200 };
             uint32_t parity{ USART_PARITY_NONE };
             InterruptPriority priority{ InterruptPriority::Normal };
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+            bool swapTxRx{ false };
+#endif
         };
     }
 

--- a/hal_st/stm32fxxx/UartStmDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDma.cpp
@@ -58,6 +58,19 @@ namespace hal
 #else
         uartHandle.Init.OverSampling = UART_OVERSAMPLING_8;
 #endif
+
+#if defined(UART_ADVFEATURE_NO_INIT)
+        uartHandle.AdvancedInit = {};
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+        if (config.swapTxRx)
+        {
+            uartHandle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_SWAP_INIT;
+            uartHandle.AdvancedInit.Swap = UART_ADVFEATURE_SWAP_ENABLE;
+        }
+#endif
+#endif
+
         HAL_UART_Init(&uartHandle);
 
         peripheralUart[uartIndex]->CR2 &= ~USART_CLOCK_ENABLED;

--- a/hal_st/stm32fxxx/UartStmDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDma.hpp
@@ -6,6 +6,7 @@
 #include "hal_st/stm32fxxx/DmaStm.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
 #include <cstdint>
+
 #include DEVICE_HEADER
 
 namespace hal
@@ -19,6 +20,10 @@ namespace hal
             uint32_t parity{ USART_PARITY_NONE };
 
             hal::InterruptPriority priority{ hal::InterruptPriority::Normal };
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+            bool swapTxRx{ false };
+#endif
         };
     }
 

--- a/hal_st/stm32fxxx/UartStmDuplexDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.cpp
@@ -74,6 +74,18 @@ namespace hal
         uartHandle.Init.OverSampling = UART_OVERSAMPLING_16;
         uartHandle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_ENABLE;
 
+#if defined(UART_ADVFEATURE_NO_INIT)
+        uartHandle.AdvancedInit = {};
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+        if (config.swapTxRx)
+        {
+            uartHandle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_SWAP_INIT;
+            uartHandle.AdvancedInit.Swap = UART_ADVFEATURE_SWAP_ENABLE;
+        }
+#endif
+#endif
+
         HAL_UART_Init(&uartHandle);
 
 #if defined(STM32WB)

--- a/hal_st/stm32fxxx/UartStmDuplexDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.hpp
@@ -8,6 +8,8 @@
 #include <atomic>
 #include <cstdint>
 
+#include DEVICE_HEADER
+
 namespace hal
 {
     namespace detail
@@ -16,6 +18,10 @@ namespace hal
         {
             uint32_t baudrate{ 115200 };
             hal::InterruptPriority priority{ hal::InterruptPriority::Normal };
+
+#if defined(UART_ADVFEATURE_SWAP_INIT)
+            bool swapTxRx{ false };
+#endif
         };
     }
 


### PR DESCRIPTION
Add UART pin swapping option for supported devices.
Using feature testing via known defines we can add an optional configuration option to optionally swap the Tx and Rx pins.

This is an advanced feature of the UART peripherals of the WB, G0, G4 and F7 series.