### PR TITLE
ci: update moved release-please-action action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+      - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4.1.1
         id: release
         with:
           token: ${{ secrets.AUTOMATIC_RELEASE_TOKEN }}


### PR DESCRIPTION
google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.