### PR TITLE
feat: Extend I2C for stm32wba family

### DIFF
--- a/hal_st/stm32fxxx/I2cStm.cpp
+++ b/hal_st/stm32fxxx/I2cStm.cpp
@@ -21,7 +21,7 @@ namespace hal
         EnableClockI2c(instance);
 
         i2cHandle.Instance = peripheralI2c[instance];
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_TIMINGR_PRESC)
         i2cHandle.Init.Timing = config.timing;
         i2cHandle.Init.OwnAddress2Masks = I2C_OA2_NOMASK;
 #endif
@@ -65,7 +65,7 @@ namespace hal
 
         __DMB();
 
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_CR1_TXIE)
         peripheralI2c[instance]->CR2 = ((address.address << 1) & I2C_CR2_SADD) | (continuingPrevious ? 0 : I2C_CR2_START) | (std::min<uint32_t>(sendData.size(), 255) << 16) | (sendData.size() > 255 || nextAction == Action::continueSession ? I2C_CR2_RELOAD : 0);
         peripheralI2c[instance]->CR1 |= I2C_CR1_TXIE | I2C_CR1_TCIE | I2C_CR1_NACKIE | I2C_CR1_ERRIE;
 #else
@@ -93,7 +93,7 @@ namespace hal
 
         __DMB();
 
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_ICR_STOPCF)
         peripheralI2c[instance]->ICR = I2C_ICR_STOPCF;
         peripheralI2c[instance]->CR2 = ((address.address << 1) & I2C_CR2_SADD) | I2C_CR2_RD_WRN | (continuingPrevious ? 0 : I2C_CR2_START) | (std::min<uint32_t>(receiveData.size(), 255) << 16) | (receiveData.size() > 255 || nextAction == Action::continueSession ? I2C_CR2_RELOAD : 0);
         peripheralI2c[instance]->CR1 |= I2C_CR1_RXIE | I2C_CR1_TCIE | I2C_CR1_NACKIE | I2C_CR1_ERRIE;
@@ -126,7 +126,7 @@ namespace hal
 
     void I2cStm::EventInterrupt()
     {
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_ISR_TXE)
         if ((peripheralI2c[instance]->ISR & I2C_ISR_NACKF) != 0)
         {
             peripheralI2c[instance]->CR1 &= ~(I2C_CR1_TXIE | I2C_CR1_RXIE | I2C_CR1_TCIE | I2C_CR1_NACKIE | I2C_CR1_ERRIE);
@@ -308,7 +308,7 @@ namespace hal
 
     void I2cStm::ErrorInterrupt()
     {
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_ISR_BERR)
         if ((peripheralI2c[instance]->ISR & I2C_ISR_BERR) != 0)
         {
             peripheralI2c[instance]->ICR |= I2C_ISR_BERR;
@@ -372,7 +372,7 @@ namespace hal
 #endif
     }
 
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_ISR_TXE)
     void I2cStm::ReadReceivedData()
     {
         while ((peripheralI2c[instance]->ISR & I2C_ISR_RXNE) != 0)

--- a/hal_st/stm32fxxx/I2cStm.hpp
+++ b/hal_st/stm32fxxx/I2cStm.hpp
@@ -18,10 +18,10 @@ namespace hal
             constexpr Config()
             {}
 
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_TIMINGR_PRESC)
             uint32_t timing = 0x00304d4d;
 #endif
-#if defined(STM32F2) || defined(STM32F4)
+#if defined(I2C_CCR_CCR)
             uint32_t clockSpeed = 400000;
 #endif
         };
@@ -40,7 +40,7 @@ namespace hal
     private:
         void EventInterrupt();
         void ErrorInterrupt();
-#if defined(STM32F0) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4) || defined(STM32G0) || defined(STM32WBA)
+#if defined(I2C_ISR_TXE)
         void ReadReceivedData();
 #endif
 


### PR DESCRIPTION
# Description
Extend hal_st to support I2C on new family STM32WBA5xx using the development board with STM32WBA52CG.

I tested only in the STM32WBA52CG. For the other families, considering the necessary changes, I'm assuming the build is enough to validate compatibility.

The modification is not really relevant, but this time is useful to validate in the new MCU and check the other datasheets over for the best way to test features instead of families.