### PR TITLE
chore: use less generic define for usb driver

### DIFF
--- a/hal_st/stm32fxxx/UsbLinkLayerStm.cpp
+++ b/hal_st/stm32fxxx/UsbLinkLayerStm.cpp
@@ -1,7 +1,7 @@
 #include "hal_st/stm32fxxx/UsbLinkLayerStm.hpp"
 #include <cstdlib>
 
-#ifdef HAS_PERIPHERAL_USB
+#if defined(USB_OTG_FS)
 
 extern "C" void OTG_FS_IRQHandler(void)
 {

--- a/hal_st/stm32fxxx/UsbLinkLayerStm.hpp
+++ b/hal_st/stm32fxxx/UsbLinkLayerStm.hpp
@@ -7,7 +7,7 @@
 #include "hal_st/stm32fxxx/GpioStm.hpp"
 #include "infra/util/InterfaceConnector.hpp"
 
-#ifdef HAS_PERIPHERAL_USB
+#if defined(USB_OTG_FS)
 
 namespace hal
 {


### PR DESCRIPTION
As implementation is for USB OTG FS, avoid building it for microcontrollers with USB but without OTG FS.