### PR TITLE
feat: add SPI master for mcu stm32wba

### DIFF
--- a/hal_st/stm32fxxx/CMakeLists.txt
+++ b/hal_st/stm32fxxx/CMakeLists.txt
@@ -39,6 +39,8 @@ target_sources(hal_st.stm32fxxx PRIVATE
     $<$<STREQUAL:${TARGET_MCU},stm32g474>:DefaultClockNucleoG474RE.hpp>
     $<$<STREQUAL:${TARGET_MCU},stm32wb55>:DefaultClockNucleoWB55RG.cpp>
     $<$<STREQUAL:${TARGET_MCU},stm32wb55>:DefaultClockNucleoWB55RG.hpp>
+    $<$<STREQUAL:${TARGET_MCU},stm32wba52>:DefaultClockNucleoWBA52CG.cpp>
+    $<$<STREQUAL:${TARGET_MCU},stm32wba52>:DefaultClockNucleoWBA52CG.hpp>
     DigitalToAnalogPinStm.cpp
     DigitalToAnalogPinStm.hpp
     $<$<NOT:$<STREQUAL:${TARGET_MCU_FAMILY},stm32g0xx>>:DmaStm.cpp>

--- a/hal_st/stm32fxxx/DefaultClockNucleoWBA52CG.cpp
+++ b/hal_st/stm32fxxx/DefaultClockNucleoWBA52CG.cpp
@@ -29,24 +29,27 @@ void ConfigureDefaultClockNucleoWBA52CG()
   /* Activate PLL with HSE as source */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
   RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.HSEDiv = RCC_HSE_DIV1;
   RCC_OscInitStruct.PLL1.PLLState = RCC_PLL_ON;
   RCC_OscInitStruct.PLL1.PLLSource = RCC_PLLSOURCE_HSE;
-  RCC_OscInitStruct.PLL1.PLLFractional = 0;
   RCC_OscInitStruct.PLL1.PLLM = 4;
   RCC_OscInitStruct.PLL1.PLLN = 25;   /* VCO = HSE/M * N = 32 / 4 * 25 = 200 MHz */
   RCC_OscInitStruct.PLL1.PLLR = 2;    /* PLLSYS = 200 MHz / 2 = 100 MHz */
   RCC_OscInitStruct.PLL1.PLLP = 2;
-  RCC_OscInitStruct.PLL1.PLLQ = 1;
+  RCC_OscInitStruct.PLL1.PLLQ = 2;
+  RCC_OscInitStruct.PLL1.PLLFractional = 0;
   HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
   /* Select PLL as system clock source and configure the HCLK, PCLK1, PCLK2 and PCLK7
      clocks dividers */
   RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 |
-                                 RCC_CLOCKTYPE_PCLK2 | RCC_CLOCKTYPE_PCLK7);
+                                 RCC_CLOCKTYPE_PCLK2 | RCC_CLOCKTYPE_PCLK7 | RCC_CLOCKTYPE_HCLK5);
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
   RCC_ClkInitStruct.APB7CLKDivider = RCC_HCLK_DIV1;
-  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4);
+  RCC_ClkInitStruct.AHB5_PLL1_CLKDivider = RCC_SYSCLK_PLL1_DIV4;
+  RCC_ClkInitStruct.AHB5_HSEHSI_CLKDivider = RCC_SYSCLK_HSEHSI_DIV1;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_3);
 }

--- a/hal_st/stm32fxxx/SpiMasterStm.cpp
+++ b/hal_st/stm32fxxx/SpiMasterStm.cpp
@@ -87,11 +87,11 @@ namespace hal
             });
 
 #ifdef SPI_IER_RXPIE
-        peripheralSpi[spiInstance]->IER |= SPI_IT_TXP;
-        peripheralSpi[spiInstance]->IER |= SPI_IT_RXP;
+        peripheralSpi[spiInstance]->IER |= SPI_IER_TXPIE;
+        peripheralSpi[spiInstance]->IER |= SPI_IER_RXPIE;
 #else
-        peripheralSpi[spiInstance]->CR2 |= SPI_IT_TXE;
-        peripheralSpi[spiInstance]->CR2 |= SPI_IT_RXNE;
+        peripheralSpi[spiInstance]->CR2 |= SPI_CR2_TXEIE;
+        peripheralSpi[spiInstance]->CR2 |= SPI_CR2_RXNEIE;
 #endif
     }
 
@@ -117,27 +117,27 @@ namespace hal
     void SpiMasterStm::HandleInterrupt()
     {
         uint32_t status = peripheralSpi[spiInstance]->SR;
-#ifdef SPI_FLAG_RXNE
-        if ((status & SPI_FLAG_RXNE) != 0)
+#ifdef SPI_SR_RXNE
+        if ((status & SPI_SR_RXNE) != 0)
 #else
-        if ((status & SPI_IT_RXP) != 0)
+        if ((status & SPI_SR_RXP) != 0)
 #endif
         {
             if (dummyToReceive != 0)
             {
-#ifdef SPI_RXDR_RXDR
-                (void)peripheralSpi[spiInstance]->RXDR;
-#else
+#ifdef SPI_DR_DR
                 (void)peripheralSpi[spiInstance]->DR;
+#else
+                (void)peripheralSpi[spiInstance]->RXDR;
 #endif
                 --dummyToReceive;
             }
             else if (receiving)
             {
-#ifdef SPI_RXDR_RXDR
-                receiveData.front() = peripheralSpi[spiInstance]->RXDR;
-#else
+#ifdef SPI_DR_DR
                 receiveData.front() = peripheralSpi[spiInstance]->DR;
+#else
+                receiveData.front() = peripheralSpi[spiInstance]->RXDR;
 #endif
                 receiveData.pop_front();
             }
@@ -145,35 +145,34 @@ namespace hal
             receiving &= !receiveData.empty();
 
             if (dummyToReceive == 0 && !receiving)
-#ifdef SPI_IER_RXPIE
-                peripheralSpi[spiInstance]->IER &= ~SPI_IT_RXP;
+#ifdef SPI_CR2_RXNEIE
+                peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_RXNEIE;
 #else
-                peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_RXNE;
+                peripheralSpi[spiInstance]->IER &= ~SPI_IER_RXPIE;
 #endif
         }
-
-#ifdef SPI_SR_TXP
-        if ((status & SPI_FLAG_TXP) != 0)
+#ifdef SPI_SR_TXE
+        if ((status & SPI_SR_TXE) != 0)
 #else
-        if ((status & SPI_FLAG_TXE) != 0)
+        if ((status & SPI_SR_TXP) != 0)
 #endif
         {
             if (dummyToSend != 0)
             {
-#ifdef SPI_TXDR_TXDR
-                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->TXDR) = 0;
-#else
+#ifdef SPI_DR_DR
                 reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = 0;
+#else
+                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->TXDR) = 0;
 #endif
                 --dummyToSend;
             }
             else if (sending)
             {
-#ifdef SPI_TXDR_TXDR
+#ifdef SPI_DR_DR
+                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = sendData.front();
+#else
                 reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->TXDR) = sendData.front();
                 peripheralSpi[spiInstance]->CR1 |= SPI_CR1_CSTART;
-#else
-                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = sendData.front();
 #endif
                 sendData.pop_front();
             }
@@ -182,14 +181,14 @@ namespace hal
 
             // After the first transmit, disable interrupt on transmit buffer empty,
             // so that a receive is done before each transmit
-#ifdef SPI_IER_TXPIE
-            peripheralSpi[spiInstance]->IER &= ~SPI_IT_TXP;
+#ifdef SPI_CR2_TXEIE
+            peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_TXEIE;
 #else
-            peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_TXE;
+            peripheralSpi[spiInstance]->IER &= ~SPI_IER_TXPIE;
 #endif
         }
 
-        really_assert(!(peripheralSpi[spiInstance]->SR & SPI_FLAG_OVR));
+        really_assert(!(peripheralSpi[spiInstance]->SR & SPI_SR_OVR));
 
         spiInterruptRegistration->ClearPending();
 

--- a/hal_st/stm32fxxx/SpiMasterStm.hpp
+++ b/hal_st/stm32fxxx/SpiMasterStm.hpp
@@ -24,6 +24,7 @@ namespace hal
         };
 
         SpiMasterStm(uint8_t oneBasedSpiIndex, GpioPinStm& clock, GpioPinStm& miso, GpioPinStm& mosi, const Config& config = Config(), GpioPinStm& slaveSelect = dummyPinStm);
+        ~SpiMasterStm();
 
         void SendAndReceive(infra::ConstByteRange sendData, infra::ByteRange receiveData, SpiAction nextAction, const infra::Function<void()>& onDone) override;
         void SetChipSelectConfigurator(ChipSelectConfigurator& configurator) override;

--- a/hal_st/stm32fxxx/SpiMasterStmDma.cpp
+++ b/hal_st/stm32fxxx/SpiMasterStmDma.cpp
@@ -9,48 +9,66 @@ namespace hal
         , miso(miso, PinConfigTypeStm::spiMiso, oneBasedSpiIndex)
         , mosi(mosi, PinConfigTypeStm::spiMosi, oneBasedSpiIndex)
         , slaveSelect(slaveSelect, PinConfigTypeStm::spiSlaveSelect, oneBasedSpiIndex)
-#if defined(STM32WBA)
+#ifdef SPI_TXDR_TXDR
         , tx(transmitStream, &peripheralSpi[spiInstance]->TXDR, 1, [this]()
-              {
-                  SendDone();
-              })
-        , rx(receiveStream, &peripheralSpi[spiInstance]->RXDR, 1, [this]()
-              {
-                  ReceiveDone();
-              })
 #else
         , tx(transmitStream, &peripheralSpi[spiInstance]->DR, 1, [this]()
+#endif
               {
                   SendDone();
               })
+#ifdef SPI_RXDR_RXDR
+        , rx(receiveStream, &peripheralSpi[spiInstance]->RXDR, 1, [this]()
+#else
         , rx(receiveStream, &peripheralSpi[spiInstance]->DR, 1, [this]()
+#endif
               {
                   ReceiveDone();
               })
-#endif
     {
         EnableClockSpi(spiInstance);
 
-        SPI_HandleTypeDef hspi;
+        SPI_HandleTypeDef hspi{};
         hspi.Instance = peripheralSpi[spiInstance];
         hspi.Init.Mode = SPI_MODE_MASTER;
         hspi.Init.Direction = SPI_DIRECTION_2LINES;
         hspi.Init.DataSize = SPI_DATASIZE_8BIT;
-        hspi.Init.CLKPolarity = SPI_POLARITY_LOW;
-        hspi.Init.CLKPhase = SPI_PHASE_1EDGE;
+        hspi.Init.CLKPolarity = config.polarityLow ? SPI_POLARITY_LOW : SPI_POLARITY_HIGH;
+        hspi.Init.CLKPhase = config.phase1st ? SPI_PHASE_1EDGE : SPI_PHASE_2EDGE;
         hspi.Init.NSS = SPI_NSS_SOFT;
-#if defined(STM32F0) || defined(STM32F3) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4)
-        hspi.Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
-#endif
         hspi.Init.BaudRatePrescaler = config.baudRatePrescaler;
         hspi.Init.FirstBit = config.msbFirst ? SPI_FIRSTBIT_MSB : SPI_FIRSTBIT_LSB;
         hspi.Init.TIMode = SPI_TIMODE_DISABLED;
         hspi.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLED;
         hspi.Init.CRCPolynomial = 1;
+
+#ifdef SPI_CRC_LENGTH_DATASIZE
+        hspi.Init.CRCLength = SPI_CRC_LENGTH_8BIT;
+#endif
+#ifdef SPI_NSS_PULSE_DISABLE
+        hspi.Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
+#endif
+#ifdef SPI_CFG2_RDIMM
+        hspi.Init.ReadyMasterManagement = SPI_RDY_MASTER_MANAGEMENT_INTERNALLY;
+#endif
+#ifdef SPI_CFG2_RDIOP
+        hspi.Init.ReadyPolarity = SPI_RDY_POLARITY_HIGH;
+#endif
+#ifdef SPI_CFG1_FTHLV
+        hspi.Init.FifoThreshold = SPI_FIFO_THRESHOLD_01DATA;
+#endif
+#ifdef SPI_CR1_MASRX
+        hspi.Init.MasterReceiverAutoSusp = SPI_MASTER_RX_AUTOSUSP_DISABLE;
+#endif
         HAL_SPI_Init(&hspi);
 
-        __HAL_SPI_ENABLE(&hspi);
         EnableDma();
+    }
+
+    SpiMasterStmDma::~SpiMasterStmDma()
+    {
+        peripheralSpi[spiInstance]->CR1 &= ~SPI_CR1_SPE;
+        DisableClockSpi(spiInstance);
     }
 
     void SpiMasterStmDma::SendAndReceive(infra::ConstByteRange sendData, infra::ByteRange receiveData, SpiAction nextAction, const infra::Function<void()>& onDone)
@@ -112,6 +130,11 @@ namespace hal
         }
         else
             std::abort();
+        
+#ifdef SPI_CR1_CSTART
+        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_CSTART;
+#endif
+        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_SPE;
     }
 
     void SpiMasterStmDma::SetChipSelectConfigurator(ChipSelectConfigurator& configurator)
@@ -136,39 +159,35 @@ namespace hal
 
     void SpiMasterStmDma::SetDataSize(uint8_t dataSizeInBits)
     {
-        DisableDma();
         peripheralSpi[spiInstance]->CR1 &= ~SPI_CR1_SPE;
+        DisableDma();
 
         tx.SetPeripheralTransferSize(dataSizeInBits <= 8 ? 1 : 2);
         rx.SetPeripheralTransferSize(dataSizeInBits <= 8 ? 1 : 2);
 
-#if defined(STM32F0) || defined(STM32F3) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4)
+#if defined(SPI_CR2_DS)
         assert(dataSizeInBits >= 4 && dataSizeInBits <= 16);
         peripheralSpi[spiInstance]->CR2 = (peripheralSpi[spiInstance]->CR2 & ~SPI_CR2_DS) | ((dataSizeInBits - 1) << POSITION_VAL(SPI_CR2_DS)) | (dataSizeInBits <= 8 ? SPI_CR2_FRXTH : 0);
-#elif defined(STM32WBA)
-        assert(dataSizeInBits == 8 || dataSizeInBits == 16);
-        peripheralSpi[spiInstance]->CR1 = peripheralSpi[spiInstance]->CR1 & ~SPI_CR1_SPE | (dataSizeInBits == 16 ? SPI_CR1_SPE : 0);
+#elif defined(SPI_CFG1_DSIZE)
+        assert(dataSizeInBits >= 4 || dataSizeInBits <= 32);
+        peripheralSpi[spiInstance]->CFG1 = (peripheralSpi[spiInstance]->CFG1 & ~SPI_CFG1_DSIZE) | ((dataSizeInBits - 1) << POSITION_VAL(SPI_CFG1_DSIZE));
 #else
         assert(dataSizeInBits == 8 || dataSizeInBits == 16);
         peripheralSpi[spiInstance]->CR1 = peripheralSpi[spiInstance]->CR1 & ~SPI_CR1_DFF | (dataSizeInBits == 16 ? SPI_CR1_DFF : 0);
 #endif
 
-        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_SPE;
-
         EnableDma();
+        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_SPE;
     }
 
     uint8_t SpiMasterStmDma::DataSize() const
     {
-#if defined(STM32F0) || defined(STM32F3) || defined(STM32F7) || defined(STM32WB) || defined(STM32G4)
+#if defined(SPI_CR2_DS)
         return ((peripheralSpi[spiInstance]->CR2 & SPI_CR2_DS) >> POSITION_VAL(SPI_CR2_DS)) + 1;
+#elif defined(SPI_CFG1_DSIZE)
+        return ((peripheralSpi[spiInstance]->CFG1 & SPI_CFG1_DSIZE) >> POSITION_VAL(SPI_CFG1_DSIZE)) + 1;
 #else
-#if !defined(STM32WBA)
         if ((peripheralSpi[spiInstance]->CR1 & SPI_CR1_DFF) != 0)
-#else
-        if ((peripheralSpi[spiInstance]->CR1 & SPI_CR1_SPE) != 0)
-
-#endif
             return 16;
         else
             return 8;
@@ -206,23 +225,23 @@ namespace hal
 
     void SpiMasterStmDma::EnableDma()
     {
-#if !defined(STM32WBA)
+#ifdef SPI_CFG1_TXDMAEN
+        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_RXDMAEN;
+        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_TXDMAEN;
+#else
         peripheralSpi[spiInstance]->CR2 |= SPI_CR2_RXDMAEN;
         peripheralSpi[spiInstance]->CR2 |= SPI_CR2_TXDMAEN;
-#else
-        peripheralSpi[spiInstance]->CR2 |= SPI_CFG1_RXDMAEN;
-        peripheralSpi[spiInstance]->CR2 |= SPI_CFG1_TXDMAEN;
 #endif
     }
 
     void SpiMasterStmDma::DisableDma()
     {
-#if !defined(STM32WBA)
+#ifdef SPI_CFG1_TXDMAEN
+        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_TXDMAEN;
+        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_RXDMAEN;
+#else
         peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_TXDMAEN;
         peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_RXDMAEN;
-#else
-        peripheralSpi[spiInstance]->CR2 &= ~SPI_CFG1_TXDMAEN;
-        peripheralSpi[spiInstance]->CR2 &= ~SPI_CFG1_RXDMAEN;
 #endif
     }
 }

--- a/hal_st/stm32fxxx/SpiMasterStmDma.cpp
+++ b/hal_st/stm32fxxx/SpiMasterStmDma.cpp
@@ -225,23 +225,23 @@ namespace hal
 
     void SpiMasterStmDma::EnableDma()
     {
-#ifdef SPI_CFG1_TXDMAEN
-        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_RXDMAEN;
-        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_TXDMAEN;
-#else
+#ifdef SPI_CR2_RXDMAEN
         peripheralSpi[spiInstance]->CR2 |= SPI_CR2_RXDMAEN;
         peripheralSpi[spiInstance]->CR2 |= SPI_CR2_TXDMAEN;
+#else
+        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_RXDMAEN;
+        peripheralSpi[spiInstance]->CFG1 |= SPI_CFG1_TXDMAEN;
 #endif
     }
 
     void SpiMasterStmDma::DisableDma()
     {
-#ifdef SPI_CFG1_TXDMAEN
-        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_TXDMAEN;
-        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_RXDMAEN;
-#else
+#ifdef SPI_CR2_TXDMAEN
         peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_TXDMAEN;
         peripheralSpi[spiInstance]->CR2 &= ~SPI_CR2_RXDMAEN;
+#else
+        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_TXDMAEN;
+        peripheralSpi[spiInstance]->CFG1 &= ~SPI_CFG1_RXDMAEN;
 #endif
     }
 }

--- a/hal_st/stm32fxxx/SpiMasterStmDma.hpp
+++ b/hal_st/stm32fxxx/SpiMasterStmDma.hpp
@@ -13,6 +13,8 @@ namespace hal
         struct SpiMasterStmDmaConfig
         {
             bool msbFirst{ true };
+            bool polarityLow{true};
+            bool phase1st{true};
             uint32_t baudRatePrescaler{ SPI_BAUDRATEPRESCALER_16 };
         };
     }
@@ -24,6 +26,7 @@ namespace hal
         using Config = detail::SpiMasterStmDmaConfig;
 
         SpiMasterStmDma(hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedSpiIndex, GpioPinStm& clock, GpioPinStm& miso, GpioPinStm& mosi, const Config& config = Config(), GpioPinStm& slaveSelect = dummyPinStm);
+        ~SpiMasterStmDma();
 
         void SendAndReceive(infra::ConstByteRange sendData, infra::ByteRange receiveData, SpiAction nextAction, const infra::Function<void()>& onDone) override;
         void SetChipSelectConfigurator(ChipSelectConfigurator& configurator) override;

--- a/hal_st/synchronous_stm32fxxx/SynchronousSpiMasterStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousSpiMasterStm.cpp
@@ -13,6 +13,7 @@ namespace hal
     {
         EnableClockSpi(spiInstance);
 
+        SPI_HandleTypeDef spiHandle{};
         spiHandle.Instance = peripheralSpi[spiInstance];
         spiHandle.Init.Mode = SPI_MODE_MASTER;
         spiHandle.Init.Direction = SPI_DIRECTION_2LINES;
@@ -25,13 +26,28 @@ namespace hal
         spiHandle.Init.TIMode = SPI_TIMODE_DISABLED;
         spiHandle.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLED;
         spiHandle.Init.CRCPolynomial = 1;
-#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F7) || defined(STM32WB)
+
+#ifdef SPI_CRC_LENGTH_DATASIZE
         spiHandle.Init.CRCLength = SPI_CRC_LENGTH_8BIT;
+#endif
+#ifdef SPI_NSS_PULSE_DISABLE
         spiHandle.Init.NSSPMode = SPI_NSS_PULSE_DISABLE;
+#endif
+#ifdef SPI_CFG2_RDIMM
+        spiHandle.Init.ReadyMasterManagement = SPI_RDY_MASTER_MANAGEMENT_INTERNALLY;
+#endif
+#ifdef SPI_CFG2_RDIOP
+        spiHandle.Init.ReadyPolarity = SPI_RDY_POLARITY_HIGH;
+#endif
+#ifdef SPI_CFG1_FTHLV
+        spiHandle.Init.FifoThreshold = SPI_FIFO_THRESHOLD_01DATA;
+#endif
+#ifdef SPI_CR1_MASRX
+        spiHandle.Init.MasterReceiverAutoSusp = SPI_MASTER_RX_AUTOSUSP_DISABLE;
 #endif
         HAL_SPI_Init(&spiHandle);
 
-#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32F7)
+#ifdef SPI_CR2_FRXTH
         peripheralSpi[spiInstance]->CR2 |= SPI_RXFIFO_THRESHOLD_QF;
 #endif
 
@@ -40,8 +56,7 @@ namespace hal
 
     SynchronousSpiMasterStm::~SynchronousSpiMasterStm()
     {
-        __HAL_SPI_DISABLE(&spiHandle);
-        HAL_SPI_DeInit(&spiHandle);
+        peripheralSpi[spiInstance]->CR1 &= ~SPI_CR1_SPE;
         DisableClockSpi(spiInstance);
     }
 
@@ -58,12 +73,12 @@ namespace hal
         if (!receiving)
             dummyToReceive = sendData.size();
 
-#if !defined(STM32WBA)
+#ifdef SPI_IER_RXPIE
+        peripheralSpi[spiInstance]->IER |= SPI_IT_TXP;
+        peripheralSpi[spiInstance]->IER |= SPI_IT_RXP;
+#else
         peripheralSpi[spiInstance]->CR2 |= SPI_IT_TXE;
         peripheralSpi[spiInstance]->CR2 |= SPI_IT_RXNE;
-#else
-        peripheralSpi[spiInstance]->CR2 |= SPI_IT_TXP;
-        peripheralSpi[spiInstance]->CR2 |= SPI_IT_RXP;
 #endif
 
         while (sending || receiving || dummyToSend != 0 || dummyToReceive != 0)
@@ -76,24 +91,24 @@ namespace hal
 #ifdef SPI_FLAG_RXNE
         if ((status & SPI_FLAG_RXNE) != 0)
 #else
-        if ((status & SPI_FLAG_RXWNE) != 0)
+        if ((status & SPI_IT_RXP) != 0)
 #endif
         {
             if (dummyToReceive != 0)
             {
-#if !defined(STM32WBA)
-                (void)peripheralSpi[spiInstance]->DR;
-#else
+#ifdef SPI_RXDR_RXDR
                 (void)peripheralSpi[spiInstance]->RXDR;
+#else
+                (void)peripheralSpi[spiInstance]->DR;
 #endif
                 --dummyToReceive;
             }
             else if (receiving)
             {
-#if !defined(STM32WBA)
-                receiveData.front() = peripheralSpi[spiInstance]->DR;
-#else
+#ifdef SPI_RXDR_RXDR
                 receiveData.front() = peripheralSpi[spiInstance]->RXDR;
+#else
+                receiveData.front() = peripheralSpi[spiInstance]->DR;
 #endif
                 receiveData.pop_front();
             }
@@ -101,34 +116,35 @@ namespace hal
             receiving &= !receiveData.empty();
 
             if (dummyToReceive == 0 && !receiving)
-#ifdef SPI_IT_RXNE
-                peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_RXNE;
+#ifdef SPI_IER_RXPIE
+                peripheralSpi[spiInstance]->IER &= ~SPI_IT_RXP;
 #else
-                peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_RXP;
+                peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_RXNE;
 #endif
         }
 
-#ifdef SPI_FLAG_TXE
-        if ((status & SPI_FLAG_TXE) != 0)
+#ifdef SPI_SR_TXP
+        if ((status & SPI_FLAG_TXP) != 0)
 #else
-        if ((status & SPI_FLAG_TXC) != 0)
+        if ((status & SPI_FLAG_TXE) != 0)
 #endif
         {
             if (dummyToSend != 0)
             {
-#if !defined(STM32WBA)
-                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = 0;
-#else
+#ifdef SPI_TXDR_TXDR
                 reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->TXDR) = 0;
+#else
+                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = 0;
 #endif
                 --dummyToSend;
             }
             else if (sending)
             {
-#if !defined(STM32WBA)
-                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = sendData.front();
-#else
+#ifdef SPI_TXDR_TXDR
                 reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->TXDR) = sendData.front();
+                peripheralSpi[spiInstance]->CR1 |= SPI_CR1_CSTART;
+#else
+                reinterpret_cast<volatile uint8_t&>(peripheralSpi[spiInstance]->DR) = sendData.front();
 #endif
                 sendData.pop_front();
             }
@@ -137,10 +153,10 @@ namespace hal
 
             // After the first transmit, disable interrupt on transmit buffer empty,
             // so that a receive is done before each transmit
-#ifdef SPI_IT_TXE
-            peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_TXE;
+#ifdef SPI_IER_TXPIE
+            peripheralSpi[spiInstance]->IER &= ~SPI_IT_TXP;
 #else
-            peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_TXP;
+            peripheralSpi[spiInstance]->CR2 &= ~SPI_IT_TXE;
 #endif
         }
 

--- a/hal_st/synchronous_stm32fxxx/SynchronousSpiMasterStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousSpiMasterStm.hpp
@@ -38,7 +38,6 @@ namespace hal
         PeripheralPinStm mosi;
         PeripheralPinStm slaveSelect;
 
-        SPI_HandleTypeDef spiHandle{};
         infra::ConstByteRange sendData;
         infra::ByteRange receiveData;
         bool sending;


### PR DESCRIPTION
# Description
Extend hal_st to support SPI for new family STM32WBA5xx.

# Details
* The SPI Master with DMA was tested with WBA52, WB55 and F767.
* Only implement the Master mode.
