### PR TITLE
fix: prescaler for ADC

### DIFF
--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
@@ -118,7 +118,7 @@ namespace hal
         adc.Measure(onDone);
     }
 
-    AdcStm::AdcStm(uint8_t oneBasedIndex)
+    AdcStm::AdcStm(uint8_t oneBasedIndex, const Config& config)
         : index(oneBasedIndex - 1)
 #if defined(STM32WB) || defined(STM32G0)
         , interruptHandler(ADC1_IRQn, [this]()
@@ -136,11 +136,7 @@ namespace hal
         EnableClockAdc(index);
 
         handle.Instance = peripheralAdc[index];
-#ifdef ADC_CLOCK_ASYNC_DIV4
-        handle.Init.ClockPrescaler = ADC_CLOCK_ASYNC_DIV4;
-#else
-        handle.Init.ClockPrescaler = ADC_CLOCKPRESCALER_PCLK_DIV4;
-#endif
+        handle.Init.ClockPrescaler = config.clockPrescaler;
         handle.Init.Resolution = ADC_RESOLUTION_12B;
         handle.Init.ScanConvMode = DISABLE;
         handle.Init.ContinuousConvMode = DISABLE;

--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
@@ -21,6 +21,15 @@ namespace hal
             uint32_t samplingTime{ ADC_SAMPLETIME_3CYCLES };
 #endif
         };
+
+        struct AdcStmConfig
+        {
+#ifdef STM32WBA
+            uint32_t clockPrescaler{ ADC_CLOCK_ASYNC_DIV4 };
+#else
+            uint32_t clockPrescaler{ ADC_CLOCKPRESCALER_PCLK_DIV4 };
+#endif
+        };
     }
 
     class AdcStm;
@@ -61,7 +70,9 @@ namespace hal
     class AdcStm
     {
     public:
-        explicit AdcStm(uint8_t adcIndex);
+        using Config = detail::AdcStmConfig;
+
+        explicit AdcStm(uint8_t adcIndex, const Config& config = Config());
         ~AdcStm();
 
     protected:


### PR DESCRIPTION
# Description

During the battery test on RCM, it was noticed an assert issue inside HAL_ST command for family STM32WB.
The prescaler assert is different between the families, reason to have a family macro oriented as a solution.