### PR TITLE
feat: add internal flash for mcu stm32wba 

### DIFF
--- a/hal_st/stm32fxxx/FlashInternalStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalStm.cpp
@@ -12,10 +12,10 @@ namespace hal
     {
         HAL_FLASH_Unlock();
 
-#if defined(STM32WB) || defined(STM32G4) || defined(STM32G0)
+#if defined(STM32WBA)
+        AlignedWriteBuffer(buffer, address);
+#elif defined(STM32WB) || defined(STM32G4) || defined(STM32G0)
         AlignedWriteBuffer<uint64_t, FLASH_TYPEPROGRAM_DOUBLEWORD>(buffer, address);
-#elif defined(STM32WBA)
-        AlignedWriteBuffer<uint64_t, FLASH_TYPEPROGRAM_QUADWORD>(buffer, address);
 #else
         uint32_t word;
         while (buffer.size() >= sizeof(word) && ((address & (sizeof(word) - 1)) == 0))
@@ -30,8 +30,6 @@ namespace hal
 
 #if defined(STM32F0) || defined(STM32F3)
         AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_HALFWORD>(buffer, address);
-#elif defined(STM32WBA)
-        AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_QUADWORD>(buffer, address);
 #elif !defined(STM32WB) && !defined(STM32G4) && !defined(STM32G0) && !defined(STM32WBA)
         for (uint8_t byte : buffer)
         {
@@ -106,6 +104,29 @@ namespace hal
             chunk = flashAlign.Next();
         }
     }
+
+#ifdef STM32WBA
+    const uint8_t alignment = sizeof(uint64_t) * 2;
+    void FlashInternalStmBase::AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address)
+    {
+        services::FlashAlign::WithAlignment<alignment> flashAlign;
+        flashAlign.Align(address, buffer);
+
+        services::FlashAlign::Chunk* chunk = flashAlign.First();
+        auto dataSize = chunk->data.size();
+        while (chunk != nullptr)
+        {
+            really_assert(chunk->data.size() % sizeof(alignment) == 0);
+            auto fullAddress = reinterpret_cast<uint32_t>(flashMemory.begin() + chunk->alignedAddress);
+
+            uint32_t addr = reinterpret_cast<uint32_t>(chunk->data.begin());
+            auto result = HAL_FLASH_Program(FLASH_TYPEPROGRAM_QUADWORD, fullAddress, addr);
+            really_assert(result == HAL_OK);
+            fullAddress += alignment;
+            chunk = flashAlign.Next();
+        }
+    }
+#endif
 
     FlashInternalStm::FlashInternalStm(infra::MemoryRange<uint32_t> sectorSizes, infra::ConstByteRange flashMemory)
         : FlashInternalStmBase(flashMemory)

--- a/hal_st/stm32fxxx/FlashInternalStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalStm.hpp
@@ -21,6 +21,9 @@ namespace hal
     private:
         template<typename alignment, uint32_t flashType>
         void AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address);
+#ifdef STM32WBA
+        void AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address);
+#endif
 
     private:
         infra::ConstByteRange flashMemory;

--- a/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalStm.cpp
@@ -11,7 +11,9 @@ namespace hal
     {
         HAL_FLASH_Unlock();
 
-#if defined(STM32WB) || defined(STM32G4) || defined(STM32G0)
+#if defined(STM32WBA)
+        AlignedWriteBuffer(buffer, address);
+#elif defined(STM32WB) || defined(STM32G4) || defined(STM32G0)
         AlignedWriteBuffer<uint64_t, FLASH_TYPEPROGRAM_DOUBLEWORD>(buffer, address);
 #elif defined(STM32WBA)
         AlignedWriteBuffer<uint64_t, FLASH_TYPEPROGRAM_QUADWORD>(buffer, address);
@@ -29,9 +31,7 @@ namespace hal
 
 #if defined(STM32F0) || defined(STM32F3)
         AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_HALFWORD>(buffer, address);
-#elif defined(STM32WBA)
-        AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_QUADWORD>(buffer, address);
-#elif !defined(STM32WB) && !defined(STM32G4) && !defined(STM32G0)
+#elif !defined(STM32WB) && !defined(STM32G4) && !defined(STM32G0) && !defined(STM32WBA)
         for (uint8_t byte : buffer)
         {
             auto result = HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, reinterpret_cast<uint32_t>(flashMemory.begin() + address), byte);
@@ -100,6 +100,29 @@ namespace hal
             chunk = flashAlign.Next();
         }
     }
+
+#ifdef STM32WBA
+    const uint8_t alignment = sizeof(uint64_t) * 2;
+    void SynchronousFlashInternalStmBase::AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address)
+    {
+        services::FlashAlign::WithAlignment<alignment> flashAlign;
+        flashAlign.Align(address, buffer);
+
+        services::FlashAlign::Chunk* chunk = flashAlign.First();
+        auto dataSize = chunk->data.size();
+        while (chunk != nullptr)
+        {
+            really_assert(chunk->data.size() % sizeof(alignment) == 0);
+            auto fullAddress = reinterpret_cast<uint32_t>(flashMemory.begin() + chunk->alignedAddress);
+
+            uint32_t addr = reinterpret_cast<uint32_t>(chunk->data.begin());
+            auto result = HAL_FLASH_Program(FLASH_TYPEPROGRAM_QUADWORD, fullAddress, addr);
+            really_assert(result == HAL_OK);
+            fullAddress += alignment;
+            chunk = flashAlign.Next();
+        }
+    }
+#endif
 
     SynchronousFlashInternalStm::SynchronousFlashInternalStm(infra::MemoryRange<uint32_t> sectorSizes, infra::ConstByteRange flashMemory)
         : SynchronousFlashInternalStmBase(flashMemory)

--- a/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalStm.hpp
@@ -20,6 +20,9 @@ namespace hal
     private:
         template<typename alignment, uint32_t flashType>
         void AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address);
+#ifdef STM32WBA
+        void AlignedWriteBuffer(infra::ConstByteRange buffer, uint32_t address);
+#endif
 
     private:
         infra::ConstByteRange flashMemory;


### PR DESCRIPTION
# Description
Extend hal_st to support internal flash for new family STM32WBA5xx.

# Details
* Tested both synchronous and asynchronous implementation.
* Created a separated solution after a sync with Richard to isolate this specific solution for memory of 128 bits.
