### PR TITLE
feat: make hal::Port's contents depend on actual available ports

### DIFF
--- a/examples/helloworld/Main.cpp
+++ b/examples/helloworld/Main.cpp
@@ -1,6 +1,8 @@
 #include "hal/interfaces/Gpio.hpp"
 #include "hal_st/instantiations/NucleoUi.hpp"
 #include "hal_st/instantiations/StmEventInfrastructure.hpp"
+#include "hal_st/stm32fxxx/DmaStm.hpp"
+#include "hal_st/stm32fxxx/UartStmDma.hpp"
 #include "infra/timer/Timer.hpp"
 #include "services/tracer/GlobalTracer.hpp"
 #include "services/tracer/StreamWriterOnSerialCommunication.hpp"

--- a/hal_st/instantiations/NucleoUi.hpp
+++ b/hal_st/instantiations/NucleoUi.hpp
@@ -1,9 +1,7 @@
 #ifndef HAL_ST_NUCLEO_UI_HPP
 #define HAL_ST_NUCLEO_UI_HPP
 
-#include "hal_st/stm32fxxx/DmaStm.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
-#include "hal_st/stm32fxxx/UartStmDma.hpp"
 
 namespace main_
 {
@@ -36,6 +34,7 @@ namespace main_
 #endif
     };
 
+#if defined(GPIOD)
     // UM2435: MB1355 reference board with STM32WB55RG
     struct Nucleo64WBUi
     {
@@ -46,6 +45,7 @@ namespace main_
         hal::GpioPinStm ledGreen{ hal::Port::B, 0 };
         hal::GpioPinStm ledBlue{ hal::Port::B, 5 };
     };
+#endif
 
     // UM3103: MB1863 reference board with STM32WBA52CG
     struct Nucleo64WBAUi

--- a/hal_st/stm32fxxx/GpioStm.cpp
+++ b/hal_st/stm32fxxx/GpioStm.cpp
@@ -7,10 +7,16 @@ namespace hal
 {
     namespace
     {
-        GPIO_TypeDef* const portToGPIOPort[] = {
+        const std::array portToGPIOPort = {
+#if defined(GPIOA)
             GPIOA,
+#endif
+#if defined(GPIOB)
             GPIOB,
+#endif
+#if defined(GPIOC)
             GPIOC,
+#endif
 #if defined(GPIOD)
             GPIOD,
 #endif
@@ -37,7 +43,7 @@ namespace hal
 #endif
         };
 
-        const uint16_t pinToGPIOPin[16] = {
+        const std::array pinToGPIOPin = {
             GPIO_PIN_0,
             GPIO_PIN_1,
             GPIO_PIN_2,
@@ -56,13 +62,13 @@ namespace hal
             GPIO_PIN_15,
         };
 
-        const uint32_t weakPullToPuPd[3] = {
+        const std::array weakPullToPuPd = {
             GPIO_NOPULL,
             GPIO_PULLUP,
             GPIO_PULLDOWN
         };
 
-        const uint32_t speedToSpeed[] = {
+        const std::array speedToSpeed = {
             GPIO_SPEED_FREQ_LOW,
             GPIO_SPEED_FREQ_MEDIUM,
             GPIO_SPEED_FREQ_HIGH,
@@ -71,7 +77,7 @@ namespace hal
 #endif
         };
 
-        const uint32_t driveToAFMode[2] = {
+        const std::array driveToAFMode = {
             GPIO_MODE_AF_PP,
             GPIO_MODE_AF_OD
         };

--- a/hal_st/stm32fxxx/GpioStm.hpp
+++ b/hal_st/stm32fxxx/GpioStm.hpp
@@ -63,17 +63,39 @@ namespace hal
 
     enum class Port : uint8_t
     {
+#if defined(GPIOA)
         A,
+#endif
+#if defined(GPIOB)
         B,
+#endif
+#if defined(GPIOC)
         C,
+#endif
+#if defined(GPIOD)
         D,
+#endif
+#if defined(GPIOE)
         E,
+#endif
+#if defined(GPIOF)
         F,
+#endif
+#if defined(GPIOG)
         G,
+#endif
+#if defined(GPIOH)
         H,
+#endif
+#if defined(GPIOI)
         I,
+#endif
+#if defined(GPIOJ)
         J,
-        K
+#endif
+#if defined(GPIOK)
+        K,
+#endif
     };
 
     enum class WeakPull : uint8_t


### PR DESCRIPTION
Align available `hal::Port::` ports to the actual ports available for the selected chip.