### PR TITLE
ci: use actions/create-github-app-token for release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,11 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
-        id: release
+      - uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        id: token
         with:
-          token: ${{ secrets.AUTOMATIC_RELEASE_TOKEN }}
+          app-id: ${{ vars.FOREST_RELEASER_APP_ID }}
+          private-key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY }}
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
+        with:
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
This PR will use actions/create-github-app-token to generate an ephemeral token on behalf of an installed app. This token is used to release using the release-please action.