### PR TITLE
fix: command sequence for flash spi with dma

### DIFF
--- a/hal_st/stm32fxxx/SpiMasterStmDma.cpp
+++ b/hal_st/stm32fxxx/SpiMasterStmDma.cpp
@@ -131,10 +131,10 @@ namespace hal
         else
             std::abort();
         
+        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_SPE;
 #ifdef SPI_CR1_CSTART
         peripheralSpi[spiInstance]->CR1 |= SPI_CR1_CSTART;
 #endif
-        peripheralSpi[spiInstance]->CR1 |= SPI_CR1_SPE;
     }
 
     void SpiMasterStmDma::SetChipSelectConfigurator(ChipSelectConfigurator& configurator)


### PR DESCRIPTION
# Description

According to the WBA manual, the **SPI_CR1_CSTART** has to be set after the **SPI_CR1_SPE** to enable the SPI with DMA since the first starts the master transfer while the second enables the peripheral. 
In other words, it was starting the transmission with the peripheral disabled.
The solution consists in reorder them.

OBS:
The **SPI_CR1_CSTART** is a command for WBA family only (until now). 