### PR TITLE
feat: prevent the CMSIS drivers from providing __cmsis_start function

### DIFF
--- a/st/hal_driver.cmake
+++ b/st/hal_driver.cmake
@@ -16,6 +16,7 @@ function(add_hal_driver target_name hal_driver cmsis)
     )
 
     target_compile_definitions(${target_name} PUBLIC
+        __PROGRAM_START=1
         USE_HAL_DRIVER=1
         USE_FULL_LL_DRIVER=1
         $<$<NOT:$<CONFIG:MinSizeRel>>:USE_FULL_ASSERT=1>


### PR DESCRIPTION
This adds a dependency on the linker to provide symbols that we don't provide. Adding this define ensures __cmsis_start is never generated.