### PR TITLE
feat: add support for ADC channel 19

### DIFF
--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
@@ -11,7 +11,7 @@ extern "C"
 
 namespace
 {
-    constexpr std::array<uint32_t, 19> adcChannel = {
+    constexpr uint32_t adcChannel[] = {
         ADC_CHANNEL_0,
         ADC_CHANNEL_1,
         ADC_CHANNEL_2,
@@ -31,7 +31,10 @@ namespace
         ADC_CHANNEL_15,
         ADC_CHANNEL_16,
         ADC_CHANNEL_17,
-        ADC_CHANNEL_18
+        ADC_CHANNEL_18,
+#endif
+#ifdef ADC_CHANNEL_19
+        ADC_CHANNEL_19,
 #endif
     };
 }


### PR DESCRIPTION
Also remove the fixed size allocation and let the compiler decide the required size.
C-style array is used because type deduction using `std::array` is not possible for all MCUs.