### PR TITLE
chore: remove duplicated lpuart struct

### DIFF
--- a/hal_st/stm32fxxx/UartStm.hpp
+++ b/hal_st/stm32fxxx/UartStm.hpp
@@ -5,7 +5,6 @@
 #include "hal/interfaces/SerialCommunication.hpp"
 #include "hal_st/cortex/InterruptCortex.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
-#include "infra/util/Optional.hpp"
 
 namespace hal
 {

--- a/hal_st/stm32fxxx/UartStmDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDma.hpp
@@ -6,19 +6,13 @@
 #include "hal_st/cortex/InterruptCortex.hpp"
 #include "hal_st/stm32fxxx/DmaStm.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
+#include "hal_st/stm32fxxx/UartStm.hpp"
 #include <cstdint>
 
 #include DEVICE_HEADER
 
 namespace hal
 {
-#if defined(HAS_PERIPHERAL_LPUART)
-    struct LpUart
-    {};
-
-    extern const LpUart lpUart;
-#endif
-
     namespace detail
     {
 


### PR DESCRIPTION
Remove the duplicated struct definition to support including both classes in same .cpp