### PR TITLE
Introduce FDCAN peripheral generation

### DIFF
--- a/hal_st/stm32fxxx/PeripheralTableH5xx.xml
+++ b/hal_st/stm32fxxx/PeripheralTableH5xx.xml
@@ -14,18 +14,21 @@
     <interrupt name="Ev" postfix="_EV"/>
     <interrupt name="Er" postfix="_ER"/>
   </peripheral>
-  <!-- <peripheral name="Can" type="CAN_TypeDef*"><item name="CAN"/>
-    <interrupt name="Tx" postfix="_TX"/>
-    <interrupt name="Rx0" postfix="_RX0"/>
-    <interrupt name="Rx1" postfix="_RX1"/>
-    <interrupt name="Sce" postfix="_SCE"/>
-  </peripheral> -->
+  <peripheral name="fdCan" type="FDCAN_GlobalTypeDef*">
+    <item name="FDCAN"/>
+    <interrupt name="It0" postfix="_IT0"/>
+    <interrupt name="It1" postfix="_IT1"/>
+  </peripheral>
   <peripheral name="Timer" type="TIM_TypeDef*" prefix="TIM">
     <item name="TIM1_8H5"/>
     <item name="TIM6_7H5"/>
   </peripheral>
-  <peripheral name="Adc" type="ADC_TypeDef*"><item name="ADC"/></peripheral>
-  <peripheral name="Dac" type="DAC_TypeDef*"><item name="DAC"/></peripheral>
+  <peripheral name="Adc" type="ADC_TypeDef*">
+    <item name="ADC"/>
+  </peripheral>
+  <peripheral name="Dac" type="DAC_TypeDef*">
+    <item name="DAC"/>
+  </peripheral>
   <!-- <peripheral name="Rng" type="RNG_TypeDef*"><item name="RNG"/></peripheral> -->
   <!-- <peripheral name="Rtc" type="RTC_TypeDef*"><item name="RTC"/></peripheral> -->
 </peripherals>

--- a/hal_st/stm32fxxx/PinoutTableItems.xml
+++ b/hal_st/stm32fxxx/PinoutTableItems.xml
@@ -96,6 +96,8 @@
   <peripheral name="Can">
     <pin name="Rx"><input name="CAN:_RX"/></pin>
     <pin name="Tx"><input name="CAN:_TX"/></pin>
+    <pin name="Rx"><input name="FDCAN:_RX"/></pin>
+    <pin name="Tx"><input name="FDCAN:_TX"/></pin>
   </peripheral>
   <peripheral name="Timer">
     <pin name="Channel1"><input name="TIM:_CH1"/></pin>


### PR DESCRIPTION
This introduces minimal FDCAN support that generates the relevant peripheral and pinout tables.