### PR TITLE
refactor: UartStmDuplexDma to reuse UartStm

### DIFF
--- a/hal_st/stm32fxxx/UartStm.cpp
+++ b/hal_st/stm32fxxx/UartStm.cpp
@@ -2,6 +2,7 @@
 #include "hal_st/stm32fxxx/GpioStm.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/BoundedVector.hpp"
+#include "infra/util/ReallyAssert.hpp"
 
 namespace hal
 {
@@ -23,6 +24,7 @@ namespace hal
         , uartArray(peripheralUart)
         , uartIrqArray(peripheralUartIrq)
     {
+        really_assert(oneBasedIndex != 0); // first element is 1 in oneBasedIndex
         RegisterInterrupt(config);
         EnableClockUart(uartIndex);
         UartStmHalInit(config, hasFlowControl);

--- a/hal_st/stm32fxxx/UartStm.hpp
+++ b/hal_st/stm32fxxx/UartStm.hpp
@@ -54,6 +54,10 @@ namespace hal
         void SendData(infra::MemoryRange<const uint8_t> data, infra::Function<void()> actionOnCompletion = infra::emptyFunction) override;
         void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
 
+    protected:
+        uint8_t uartIndex;
+        infra::Function<void(infra::ConstByteRange data)> dataReceived;
+
     private:
         void UartStmHalInit(const Config& config, bool hasFlowControl);
         void RegisterInterrupt(const Config& config);
@@ -61,7 +65,6 @@ namespace hal
         void Invoke() override;
 
     private:
-        uint8_t uartIndex;
         hal::PeripheralPinStm uartTx;
         hal::PeripheralPinStm uartRx;
         hal::PeripheralPinStm uartRts;
@@ -70,7 +73,6 @@ namespace hal
         UART_HandleTypeDef uartHandle = {};
 
         infra::Function<void()> transferDataComplete;
-        infra::Function<void(infra::ConstByteRange data)> dataReceived;
 
         infra::MemoryRange<const uint8_t> sendData;
         bool sending = false;

--- a/hal_st/stm32fxxx/UartStmDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDma.cpp
@@ -18,7 +18,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
             {
                 TransferComplete();
             } }
@@ -28,7 +28,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
             {
                 TransferComplete();
             } }
@@ -39,7 +39,7 @@ namespace hal
 #if defined(HAS_PERIPHERAL_LPUART)
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
             {
                 TransferComplete();
             } }
@@ -49,7 +49,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
             {
                 TransferComplete();
             } }

--- a/hal_st/stm32fxxx/UartStmDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDma.cpp
@@ -1,79 +1,66 @@
 #include "hal_st/stm32fxxx/UartStmDma.hpp"
 #include "generated/stm32fxxx/PeripheralTable.hpp"
 #include "infra/event/EventDispatcher.hpp"
-#include "infra/util/BoundedVector.hpp"
 
 namespace hal
 {
     namespace
     {
-        volatile void* PeripheralAddress(infra::MemoryRange<USART_TypeDef* const> table, uint8_t uartIndex)
+        volatile void* TransmitRegister(uint8_t uartIndex)
         {
 #if defined(USART_TDR_TDR)
-            return &table[uartIndex]->TDR;
+            return &peripheralUart[uartIndex]->TDR;
 #else
-            return &table[uartIndex]->DR;
+            return &peripheralUart[uartIndex]->DR;
 #endif
         }
     }
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
-        : UartStmDma{ transmitStream, oneBasedIndex, uartTx, uartRx, hal::dummyPinStm, hal::dummyPinStm, config, false }
-    {}
-
-    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
-        : UartStmDma{ transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config, true }
-    {}
-
-    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl)
-        : uartIndex(oneBasedIndex - 1)
-        , uartTx(uartTx, PinConfigTypeStm::uartTx, oneBasedIndex)
-        , uartRx(uartRx, PinConfigTypeStm::uartRx, oneBasedIndex)
-        , uartRts(uartRts, PinConfigTypeStm::uartRts, oneBasedIndex)
-        , uartCts(uartCts, PinConfigTypeStm::uartCts, oneBasedIndex)
-        , uartArray(peripheralUart)
-        , uartIrqArray(peripheralUartIrq)
-        , transmitDmaChannel{ transmitStream, PeripheralAddress(uartArray, uartIndex), 1, [this]()
+        : UartStm(oneBasedIndex, uartTx, uartRx, config)
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        RegisterInterrupt(config);
-        EnableClockUart(uartIndex);
-        UartStmHalInit(config, hasFlowControl);
+        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+    }
+
+    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
+        : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+            {
+                TransferComplete();
+            } }
+    {
+        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 
 #if defined(HAS_PERIPHERAL_LPUART)
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config)
-        : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, dummyPinStm, dummyPinStm, lpUart, config, false)
-    {}
-
-    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config)
-        : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, lpUart, config, false)
-    {}
-
-    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config, bool hasFlowControl)
-        : uartIndex(oneBasedIndex - 1)
-        , uartTx(uartTx, PinConfigTypeStm::lpuartTx, oneBasedIndex)
-        , uartRx(uartRx, PinConfigTypeStm::lpuartRx, oneBasedIndex)
-        , uartRts(uartRts, PinConfigTypeStm::lpuartRts, oneBasedIndex)
-        , uartCts(uartCts, PinConfigTypeStm::lpuartCts, oneBasedIndex)
-        , uartArray(peripheralLpuart)
-        , uartIrqArray(peripheralLpuartIrq)
-        , transmitDmaChannel{ transmitStream, PeripheralAddress(uartArray, uartIndex), 1, [this]()
+        : UartStm(oneBasedIndex, uartTx, uartRx, lpUart, config)
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        RegisterInterrupt(config);
-        EnableClockLpuart(uartIndex);
-        UartStmHalInit(config, hasFlowControl);
+        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+    }
+
+    UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config)
+        : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, lpUart, config)
+        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex), 1, [this]
+            {
+                TransferComplete();
+            } }
+    {
+        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 #endif
 
     UartStmDma::~UartStmDma()
     {
-        uartArray[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
+        peripheralUart[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
         DisableClockUart(uartIndex);
     }
 
@@ -93,53 +80,10 @@ namespace hal
         this->dataReceived = dataReceived;
 
 #if defined(STM32F4) || defined(STM32G4)
-        uartArray[uartIndex]->CR1 |= USART_IT_RXNE & USART_IT_MASK;
+        peripheralUart[uartIndex]->CR1 |= USART_IT_RXNE & USART_IT_MASK;
 #else
-        uartArray[uartIndex]->CR1 |= 1 << (USART_IT_RXNE & USART_IT_MASK);
+        peripheralUart[uartIndex]->CR1 |= 1 << (USART_IT_RXNE & USART_IT_MASK);
 #endif
-    }
-
-    void UartStmDma::UartStmHalInit(const Config& config, bool hasFlowControl)
-    {
-        UART_HandleTypeDef uartHandle = {};
-        uartHandle.Instance = uartArray[uartIndex];
-        uartHandle.Init.BaudRate = config.baudrate;
-        uartHandle.Init.WordLength = config.parity == USART_PARITY_NONE ? USART_WORDLENGTH_8B : USART_WORDLENGTH_9B;
-        uartHandle.Init.StopBits = USART_STOPBITS_1;
-        uartHandle.Init.Parity = config.parity;
-        uartHandle.Init.Mode = USART_MODE_TX_RX;
-
-        if (hasFlowControl)
-            uartHandle.Init.HwFlowCtl = UART_HWCONTROL_RTS_CTS;
-        else
-            uartHandle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
-
-#if defined(UART_ONE_BIT_SAMPLE_ENABLE)
-        uartHandle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_ENABLE;
-#endif
-        uartHandle.Init.OverSampling = UART_OVERSAMPLING_8;
-
-#if defined(UART_ADVFEATURE_NO_INIT)
-        uartHandle.AdvancedInit = {};
-
-#if defined(UART_ADVFEATURE_SWAP_INIT)
-        if (config.swapTxRx)
-        {
-            uartHandle.AdvancedInit.AdvFeatureInit = UART_ADVFEATURE_SWAP_INIT;
-            uartHandle.AdvancedInit.Swap = UART_ADVFEATURE_SWAP_ENABLE;
-        }
-#endif
-#endif
-
-        HAL_UART_Init(&uartHandle);
-
-        uartArray[uartIndex]->CR2 &= ~USART_CLOCK_ENABLED;
-        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT;
-    }
-
-    void UartStmDma::RegisterInterrupt(const Config& config)
-    {
-        Register(uartIrqArray[uartIndex], config.priority);
     }
 
     void UartStmDma::TransferComplete()
@@ -150,37 +94,5 @@ namespace hal
             transferDataComplete = nullptr;
             infra::EventDispatcher::Instance().Schedule(callback);
         }
-    }
-
-    void UartStmDma::Invoke()
-    {
-        infra::BoundedVector<uint8_t>::WithMaxSize<8> buffer;
-
-#if defined(USART_ISR_RXNE_RXFNE)
-        while (!buffer.full() && uartArray[uartIndex]->ISR & USART_ISR_RXNE_RXFNE)
-#elif defined(USART_ISR_RXNE)
-        while (!buffer.full() && uartArray[uartIndex]->ISR & USART_ISR_RXNE)
-#else
-        while (!buffer.full() && uartArray[uartIndex]->SR & USART_SR_RXNE)
-#endif
-        {
-            uint8_t receivedByte =
-#if defined(USART_RDR_RDR)
-                uartArray[uartIndex]->RDR;
-#else
-                uartArray[uartIndex]->DR;
-#endif
-            buffer.push_back(receivedByte);
-        }
-
-        // If buffer is empty then interrupt was raised by Overrun Error (ORE) and we miss data.
-#if defined(USART_ISR_ORE)
-        really_assert(!(buffer.empty() && uartArray[uartIndex]->ISR & USART_ISR_ORE));
-#else
-        really_assert(!(buffer.empty() && uartArray[uartIndex]->SR & USART_SR_ORE));
-#endif
-
-        if (dataReceived != nullptr)
-            dataReceived(buffer.range());
     }
 }

--- a/hal_st/stm32fxxx/UartStmDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDma.cpp
@@ -18,7 +18,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
@@ -28,7 +28,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
@@ -39,7 +39,7 @@ namespace hal
 #if defined(HAS_PERIPHERAL_LPUART)
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
@@ -49,7 +49,7 @@ namespace hal
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(oneBasedIndex - 1), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
             {
                 TransferComplete();
             } }

--- a/hal_st/stm32fxxx/UartStmDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDma.hpp
@@ -2,39 +2,17 @@
 #define HAL_UART_STM_DMA_HPP
 
 #include "generated/stm32fxxx/PeripheralTable.hpp"
-#include "hal/interfaces/SerialCommunication.hpp"
-#include "hal_st/cortex/InterruptCortex.hpp"
 #include "hal_st/stm32fxxx/DmaStm.hpp"
-#include "hal_st/stm32fxxx/GpioStm.hpp"
 #include "hal_st/stm32fxxx/UartStm.hpp"
 #include <cstdint>
 
-#include DEVICE_HEADER
-
 namespace hal
 {
-    namespace detail
-    {
-
-        struct UartStmDmaConfig
-        {
-            uint32_t baudrate{ 115200 };
-            uint32_t parity{ USART_PARITY_NONE };
-
-            hal::InterruptPriority priority{ hal::InterruptPriority::Normal };
-
-#if defined(UART_ADVFEATURE_SWAP_INIT)
-            bool swapTxRx{ false };
-#endif
-        };
-    }
-
     class UartStmDma
-        : public SerialCommunication
-        , private InterruptHandler
+        : public UartStm
     {
     public:
-        using Config = detail::UartStmDmaConfig;
+        using Config = detail::UartStmConfig;
 
         UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config = Config());
         UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config = Config());
@@ -44,34 +22,14 @@ namespace hal
 #endif
         ~UartStmDma();
 
-    private:
-        UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl);
-#if defined(HAS_PERIPHERAL_LPUART)
-        UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config, bool hasFlowControl);
-#endif
-
-    public:
         void SendData(infra::MemoryRange<const uint8_t> data, infra::Function<void()> actionOnCompletion = infra::emptyFunction) override;
         void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
 
     private:
-        void UartStmHalInit(const Config& config, bool hasFlowControl);
-        void RegisterInterrupt(const Config& config);
         void TransferComplete();
-        void Invoke() override;
 
-    private:
-        uint8_t uartIndex;
-        PeripheralPinStm uartTx;
-        PeripheralPinStm uartRx;
-        PeripheralPinStm uartRts;
-        PeripheralPinStm uartCts;
-        infra::MemoryRange<USART_TypeDef* const> uartArray;
-        infra::MemoryRange<IRQn_Type const> uartIrqArray;
         TransmitDmaChannel transmitDmaChannel;
-
         infra::Function<void()> transferDataComplete;
-        infra::Function<void(infra::ConstByteRange data)> dataReceived;
     };
 }
 

--- a/hal_st/stm32fxxx/UartStmDuplexDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.cpp
@@ -21,7 +21,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
             {
                 HalfReceiveComplete();
             },
@@ -36,7 +36,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
             {
                 HalfReceiveComplete();
             },
@@ -51,7 +51,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
             {
                 HalfReceiveComplete();
             },

--- a/hal_st/stm32fxxx/UartStmDuplexDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.cpp
@@ -21,7 +21,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(uartIndex), 1, [this]
             {
                 HalfReceiveComplete();
             },
@@ -36,7 +36,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(uartIndex), 1, [this]
             {
                 HalfReceiveComplete();
             },
@@ -51,7 +51,7 @@ namespace hal
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl)
         : UartStmDma(transmitStream, oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
         , rxBuffer{ rxBuffer }
-        , receiveDmaChannel{ receiveStream, ReceiveRegister(oneBasedIndex - 1), 1, [this]
+        , receiveDmaChannel{ receiveStream, ReceiveRegister(uartIndex), 1, [this]
             {
                 HalfReceiveComplete();
             },

--- a/hal_st/stm32fxxx/UartStmDuplexDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.hpp
@@ -1,42 +1,28 @@
 #ifndef HAL_UART_STM_DUPLEX_DMA_HPP
 #define HAL_UART_STM_DUPLEX_DMA_HPP
 
-#include "hal/interfaces/SerialCommunication.hpp"
-#include "hal_st/cortex/InterruptCortex.hpp"
 #include "hal_st/stm32fxxx/DmaStm.hpp"
-#include "hal_st/stm32fxxx/GpioStm.hpp"
+#include "hal_st/stm32fxxx/UartStm.hpp"
 #include <atomic>
 #include <cstdint>
 
-#include DEVICE_HEADER
-
 namespace hal
 {
-    namespace detail
-    {
-        struct UartStmDuplexDmaConfig
-        {
-            uint32_t baudrate{ 115200 };
-            hal::InterruptPriority priority{ hal::InterruptPriority::Normal };
-
-#if defined(UART_ADVFEATURE_SWAP_INIT)
-            bool swapTxRx{ false };
-#endif
-        };
-    }
-
     class UartStmDuplexDma
-        : public SerialCommunication
-        , private InterruptHandler
+        : public UartStm
     {
     public:
-        using Config = detail::UartStmDuplexDmaConfig;
+        using Config = detail::UartStmConfig;
 
         template<std::size_t RxBufferSize>
         using WithRxBuffer = infra::WithStorage<UartStmDuplexDma, std::array<uint8_t, RxBufferSize>>;
 
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config = Config());
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config = Config());
+#if defined(HAS_PERIPHERAL_LPUART)
+        UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config = Config());
+        UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config = Config());
+#endif
 
     private:
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl);
@@ -52,27 +38,19 @@ namespace hal
         void HalfReceiveComplete();
         void FullReceiveComplete();
         void ReceiveComplete(size_t currentPosition);
-        void RegisterInterrupt(const Config& config);
         void TransferComplete();
 
-        // Implementation of InterruptHandler
+        // Implementation InterruptHandler
         void Invoke() override;
 
     private:
         infra::MemoryRange<uint8_t> rxBuffer;
-        uint8_t uartIndex;
-        PeripheralPinStm uartTx;
-        PeripheralPinStm uartRx;
-        PeripheralPinStm uartRts;
-        PeripheralPinStm uartCts;
-
         hal::TransmitDmaChannel transmitDmaChannel;
         hal::CircularReceiveDmaChannel receiveDmaChannel;
-
         infra::Function<void()> transferDataComplete;
         infra::Function<void(infra::ConstByteRange data)> dataReceived;
-
         std::atomic<size_t> lastReceivedPosition{};
+        uint8_t uartIndex;
     };
 }
 

--- a/hal_st/stm32fxxx/UartStmDuplexDma.hpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.hpp
@@ -2,14 +2,14 @@
 #define HAL_UART_STM_DUPLEX_DMA_HPP
 
 #include "hal_st/stm32fxxx/DmaStm.hpp"
-#include "hal_st/stm32fxxx/UartStm.hpp"
+#include "hal_st/stm32fxxx/UartStmDma.hpp"
 #include <atomic>
 #include <cstdint>
 
 namespace hal
 {
     class UartStmDuplexDma
-        : public UartStm
+        : public UartStmDma
     {
     public:
         using Config = detail::UartStmConfig;
@@ -19,10 +19,6 @@ namespace hal
 
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config = Config());
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config = Config());
-#if defined(HAS_PERIPHERAL_LPUART)
-        UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config = Config());
-        UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config = Config());
-#endif
 
     private:
         UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl);
@@ -31,26 +27,20 @@ namespace hal
         ~UartStmDuplexDma();
 
         // Implementation of SerialCommunication
-        void SendData(infra::MemoryRange<const uint8_t> data, infra::Function<void()> actionOnCompletion = infra::emptyFunction) override;
         void ReceiveData(infra::Function<void(infra::ConstByteRange data)> dataReceived) override;
 
     private:
         void HalfReceiveComplete();
         void FullReceiveComplete();
         void ReceiveComplete(size_t currentPosition);
-        void TransferComplete();
 
         // Implementation InterruptHandler
         void Invoke() override;
 
     private:
         infra::MemoryRange<uint8_t> rxBuffer;
-        hal::TransmitDmaChannel transmitDmaChannel;
         hal::CircularReceiveDmaChannel receiveDmaChannel;
-        infra::Function<void()> transferDataComplete;
-        infra::Function<void(infra::ConstByteRange data)> dataReceived;
         std::atomic<size_t> lastReceivedPosition{};
-        uint8_t uartIndex;
     };
 }
 


### PR DESCRIPTION
There seems to be a lot of duplication with different flavour of UART's. This PR aims to reuse UartStm base class and build on top of it for DMA functionality. 
