### PR TITLE
feat: extend gpio interrupt interface to enable immediate interrupt handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        feature/extend-gpio-interrupt-interface-to-enable-immediate-interrupt-handlers # unreleased
+        GIT_TAG        95ddf856192b8eb7e7282f3cb6f4e028aef200ad # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        4dc5736b2814734a66a1de75d2eabb356d1ed6ff # unreleased
+        GIT_TAG        feature/extend-gpio-interrupt-interface-to-enable-immediate-interrupt-handlers # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/stm32fxxx/GpioStm.cpp
+++ b/hal_st/stm32fxxx/GpioStm.cpp
@@ -1,7 +1,10 @@
 #include "hal_st/stm32fxxx/GpioStm.hpp"
+#include "hal/interfaces/Gpio.hpp"
+#include "hal_st/cortex/InterruptCortex.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/BitLogic.hpp"
 #include "infra/util/ReallyAssert.hpp"
+#include DEVICE_HEADER
 
 namespace hal
 {
@@ -160,9 +163,9 @@ namespace hal
         GpioStm::Instance().ClearPinReservation(port, index);
     }
 
-    void GpioPinStm::EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger)
+    void GpioPinStm::EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type)
     {
-        GpioStm::Instance().EnableInterrupt(port, index, action, trigger);
+        GpioStm::Instance().EnableInterrupt(port, index, action, trigger, type);
     }
 
     void GpioPinStm::DisableInterrupt()
@@ -245,7 +248,7 @@ namespace hal
     void DummyPinStm::ResetConfig()
     {}
 
-    void DummyPinStm::EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger)
+    void DummyPinStm::EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type)
     {}
 
     void DummyPinStm::DisableInterrupt()
@@ -483,7 +486,7 @@ namespace hal
         abort();
     }
 
-    void GpioStm::EnableInterrupt(Port port, uint8_t index, const infra::Function<void()>& action, InterruptTrigger trigger)
+    void GpioStm::EnableInterrupt(Port port, uint8_t index, const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type)
     {
 #if defined(STM32WBA) || defined(STM32H5)
         uint8_t pos = 3;
@@ -527,6 +530,7 @@ namespace hal
 #endif
         really_assert(!handlers[index]);
         handlers[index] = action;
+        interruptTypes[index] = type;
     }
 
     void GpioStm::DisableInterrupt(Port port, uint8_t index)
@@ -558,7 +562,12 @@ namespace hal
                 EXTI->PR &= (1 << line); // Interrupt pending is cleared by writing a 1 to it
 #endif
                 if (handlers[line])
-                    infra::EventDispatcher::Instance().Schedule(handlers[line]);
+                {
+                    if (interruptTypes[line] == InterruptType::dispatched)
+                        infra::EventDispatcher::Instance().Schedule(handlers[line]);
+                    else
+                        handlers[line]();
+                }
                 NVIC_ClearPendingIRQ(irq);
             }
         }

--- a/hal_st/stm32fxxx/GpioStm.hpp
+++ b/hal_st/stm32fxxx/GpioStm.hpp
@@ -1,11 +1,12 @@
 #ifndef HAL_GPIO_STM_HPP
 #define HAL_GPIO_STM_HPP
 
-#include DEVICE_HEADER
 #include "hal/interfaces/Gpio.hpp"
 #include "hal_st/cortex/InterruptCortex.hpp"
+#include "infra/util/Function.hpp"
 #include "infra/util/MemoryRange.hpp"
 #include <cstdint>
+#include DEVICE_HEADER
 
 namespace hal
 {
@@ -136,7 +137,7 @@ namespace hal
         void Config(PinConfigType config) override;
         void Config(PinConfigType config, bool startOutputState) override;
         void ResetConfig() override;
-        void EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger) override;
+        void EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type = InterruptType::dispatched) override;
         void DisableInterrupt() override;
 
         virtual void ConfigAnalog();
@@ -167,7 +168,7 @@ namespace hal
         void Config(PinConfigType config) override;
         void Config(PinConfigType config, bool startOutputState) override;
         void ResetConfig() override;
-        void EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger) override;
+        void EnableInterrupt(const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type = InterruptType::dispatched) override;
         void DisableInterrupt() override;
         void ConfigAnalog() override;
         void ConfigPeripheral(PinConfigTypeStm pinConfigType, uint8_t peripheral) override;
@@ -268,7 +269,7 @@ namespace hal
         uint32_t AdcChannel(Port port, uint8_t index, uint8_t adc) const;
         uint32_t DacChannel(Port port, uint8_t index, uint8_t dac) const;
 
-        void EnableInterrupt(Port port, uint8_t index, const infra::Function<void()>& action, InterruptTrigger trigger);
+        void EnableInterrupt(Port port, uint8_t index, const infra::Function<void()>& action, InterruptTrigger trigger, InterruptType type);
         void DisableInterrupt(Port port, uint8_t index);
 
         void ReservePin(Port port, uint8_t index);
@@ -281,33 +282,34 @@ namespace hal
         infra::MemoryRange<const GpioStm::AnalogPinPosition> analogTable;
 
         std::array<infra::Function<void()>, 16> handlers;
+        std::array<InterruptType, 16> interruptTypes;
         std::array<uint32_t, 11> assignedPins;
 
 #if defined(STM32F0) || defined(STM32G0)
-        DispatchedInterruptHandler interruptDispatcher0_1;
-        DispatchedInterruptHandler interruptDispatcher2_3;
-        DispatchedInterruptHandler interruptDispatcher4_15;
+        ImmediateInterruptHandler interruptDispatcher0_1;
+        ImmediateInterruptHandler interruptDispatcher2_3;
+        ImmediateInterruptHandler interruptDispatcher4_15;
 #else
-        DispatchedInterruptHandler interruptDispatcher0;
-        DispatchedInterruptHandler interruptDispatcher1;
-        DispatchedInterruptHandler interruptDispatcher2;
-        DispatchedInterruptHandler interruptDispatcher3;
-        DispatchedInterruptHandler interruptDispatcher4;
+        ImmediateInterruptHandler interruptDispatcher0;
+        ImmediateInterruptHandler interruptDispatcher1;
+        ImmediateInterruptHandler interruptDispatcher2;
+        ImmediateInterruptHandler interruptDispatcher3;
+        ImmediateInterruptHandler interruptDispatcher4;
 #if defined(STM32WBA) || defined(STM32H5)
-        DispatchedInterruptHandler interruptDispatcher5;
-        DispatchedInterruptHandler interruptDispatcher6;
-        DispatchedInterruptHandler interruptDispatcher7;
-        DispatchedInterruptHandler interruptDispatcher8;
-        DispatchedInterruptHandler interruptDispatcher9;
-        DispatchedInterruptHandler interruptDispatcher10;
-        DispatchedInterruptHandler interruptDispatcher11;
-        DispatchedInterruptHandler interruptDispatcher12;
-        DispatchedInterruptHandler interruptDispatcher13;
-        DispatchedInterruptHandler interruptDispatcher14;
-        DispatchedInterruptHandler interruptDispatcher15;
+        ImmediateInterruptHandler interruptDispatcher5;
+        ImmediateInterruptHandler interruptDispatcher6;
+        ImmediateInterruptHandler interruptDispatcher7;
+        ImmediateInterruptHandler interruptDispatcher8;
+        ImmediateInterruptHandler interruptDispatcher9;
+        ImmediateInterruptHandler interruptDispatcher10;
+        ImmediateInterruptHandler interruptDispatcher11;
+        ImmediateInterruptHandler interruptDispatcher12;
+        ImmediateInterruptHandler interruptDispatcher13;
+        ImmediateInterruptHandler interruptDispatcher14;
+        ImmediateInterruptHandler interruptDispatcher15;
 #else
-        DispatchedInterruptHandler interruptDispatcher9_5;
-        DispatchedInterruptHandler interruptDispatcher15_10;
+        ImmediateInterruptHandler interruptDispatcher9_5;
+        ImmediateInterruptHandler interruptDispatcher15_10;
 #endif
 #endif
     };

--- a/hal_st/stm32fxxx/GpioStm.hpp
+++ b/hal_st/stm32fxxx/GpioStm.hpp
@@ -4,8 +4,13 @@
 #include "hal/interfaces/Gpio.hpp"
 #include "hal_st/cortex/InterruptCortex.hpp"
 #include "infra/util/Function.hpp"
+#include "infra/util/InterfaceConnector.hpp"
 #include "infra/util/MemoryRange.hpp"
+#include <array>
+#include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <utility>
 #include DEVICE_HEADER
 
 namespace hal
@@ -277,12 +282,14 @@ namespace hal
 
     private:
         void ExtiInterrupt(IRQn_Type irq, std::size_t from, std::size_t to);
+        void DispatchExtiInterrupt(std::size_t line);
 
         infra::MemoryRange<const infra::MemoryRange<const GpioStm::PinoutTable>> pinoutTable;
         infra::MemoryRange<const GpioStm::AnalogPinPosition> analogTable;
 
         std::array<infra::Function<void()>, 16> handlers;
-        std::array<InterruptType, 16> interruptTypes;
+        std::array<InterruptType, 16> interruptTypes{};
+        std::array<std::atomic_bool, 16> notificationScheduled{};
         std::array<uint32_t, 11> assignedPins;
 
 #if defined(STM32F0) || defined(STM32G0)


### PR DESCRIPTION
This change allows the user of the InterruptEnable function to choose betweeen a dispatched or immediate handling of the pin interrupt.

## Notable changes:
Removed a double dispatch. The pin change was handled using a DispatchInterruptHandler. And in the ExitInterrupt, which was handled on the EventDispatch, the actual action would be dispatched, again.

