### PR TITLE
fix: lpUart peripheral table was not used correctly with UartStmDma

### DIFF
--- a/hal_st/stm32fxxx/UartStm.hpp
+++ b/hal_st/stm32fxxx/UartStm.hpp
@@ -57,6 +57,7 @@ namespace hal
     protected:
         uint8_t uartIndex;
         infra::Function<void(infra::ConstByteRange data)> dataReceived;
+        infra::MemoryRange<USART_TypeDef* const> uartArray;
 
     private:
         void UartStmHalInit(const Config& config, bool hasFlowControl);
@@ -76,8 +77,6 @@ namespace hal
 
         infra::MemoryRange<const uint8_t> sendData;
         bool sending = false;
-
-        infra::MemoryRange<USART_TypeDef* const> uartArray;
         infra::MemoryRange<IRQn_Type const> uartIrqArray;
     };
 }

--- a/hal_st/stm32fxxx/UartStmDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDma.cpp
@@ -6,61 +6,61 @@ namespace hal
 {
     namespace
     {
-        volatile void* TransmitRegister(uint8_t uartIndex)
+        volatile void* TransmitRegister(infra::MemoryRange<USART_TypeDef* const> table, uint8_t uartIndex)
         {
 #if defined(USART_TDR_TDR)
-            return &peripheralUart[uartIndex]->TDR;
+            return &table[uartIndex]->TDR;
 #else
-            return &peripheralUart[uartIndex]->DR;
+            return &table[uartIndex]->DR;
 #endif
         }
     }
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(peripheralUart, uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(peripheralUart, uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 
 #if defined(HAS_PERIPHERAL_LPUART)
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(peripheralLpuart, uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 
     UartStmDma::UartStmDma(DmaStm::TransmitStream& transmitStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, LpUart lpUart, const Config& config)
         : UartStm(oneBasedIndex, uartTx, uartRx, uartRts, uartCts, lpUart, config)
-        , transmitDmaChannel{ transmitStream, TransmitRegister(uartIndex), 1, [this]
+        , transmitDmaChannel{ transmitStream, TransmitRegister(peripheralLpuart, uartIndex), 1, [this]
             {
                 TransferComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT;
     }
 #endif
 
     UartStmDma::~UartStmDma()
     {
-        peripheralUart[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
+        uartArray[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
         DisableClockUart(uartIndex);
     }
 
@@ -80,9 +80,9 @@ namespace hal
         this->dataReceived = dataReceived;
 
 #if defined(STM32F4) || defined(STM32G4)
-        peripheralUart[uartIndex]->CR1 |= USART_IT_RXNE & USART_IT_MASK;
+        uartArray[uartIndex]->CR1 |= USART_IT_RXNE & USART_IT_MASK;
 #else
-        peripheralUart[uartIndex]->CR1 |= 1 << (USART_IT_RXNE & USART_IT_MASK);
+        uartArray[uartIndex]->CR1 |= 1 << (USART_IT_RXNE & USART_IT_MASK);
 #endif
     }
 

--- a/hal_st/stm32fxxx/UartStmDuplexDma.cpp
+++ b/hal_st/stm32fxxx/UartStmDuplexDma.cpp
@@ -30,7 +30,7 @@ namespace hal
                 FullReceiveComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
     }
 
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config)
@@ -45,7 +45,7 @@ namespace hal
                 FullReceiveComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
     }
 
     UartStmDuplexDma::UartStmDuplexDma(infra::MemoryRange<uint8_t> rxBuffer, hal::DmaStm::TransmitStream& transmitStream, hal::DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedIndex, GpioPinStm& uartTx, GpioPinStm& uartRx, GpioPinStm& uartRts, GpioPinStm& uartCts, const Config& config, bool hasFlowControl)
@@ -60,13 +60,13 @@ namespace hal
                 FullReceiveComplete();
             } }
     {
-        peripheralUart[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
+        uartArray[uartIndex]->CR3 |= USART_CR3_DMAT | USART_CR3_DMAR;
     }
 
     UartStmDuplexDma::~UartStmDuplexDma()
     {
         receiveDmaChannel.StopTransfer();
-        peripheralUart[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
+        uartArray[uartIndex]->CR1 &= ~(USART_CR1_TE | USART_CR1_RE);
         DisableClockUart(uartIndex);
     }
 
@@ -80,9 +80,9 @@ namespace hal
         {
             receiveDmaChannel.StartReceive(rxBuffer);
 
-            peripheralUart[uartIndex]->CR2 |= USART_CR2_RTOEN;
-            peripheralUart[uartIndex]->CR1 |= USART_CR1_RE | USART_CR1_RTOIE;
-            peripheralUart[uartIndex]->RTOR = defaultRxTimeout;
+            uartArray[uartIndex]->CR2 |= USART_CR2_RTOEN;
+            uartArray[uartIndex]->CR1 |= USART_CR1_RE | USART_CR1_RTOIE;
+            uartArray[uartIndex]->RTOR = defaultRxTimeout;
         }
     }
 
@@ -112,9 +112,9 @@ namespace hal
 
     void UartStmDuplexDma::Invoke()
     {
-        if (peripheralUart[uartIndex]->ISR & USART_ISR_RTOF)
+        if (uartArray[uartIndex]->ISR & USART_ISR_RTOF)
         {
-            peripheralUart[uartIndex]->ICR = USART_ICR_RTOCF;
+            uartArray[uartIndex]->ICR = USART_ICR_RTOCF;
 
             const auto receivedSize = receiveDmaChannel.ReceivedSize();
 


### PR DESCRIPTION
- UartStmDma is using the incorrect peripheral table when used with lpUart. 