### PR TITLE
fix: GAP connection procedure

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -250,10 +250,11 @@ namespace hal
 
     void GapCentralSt::HandleGapDirectConnectionProcedureCompleteEvent()
     {
-        infra::Subject<services::GapCentralObserver>::NotifyObservers([](services::GapCentralObserver& observer)
-            {
-                observer.StateChanged(services::GapState::standby);
-            });
+        if (!initiatingStateTimer.Armed())
+            infra::Subject<services::GapCentralObserver>::NotifyObservers([](services::GapCentralObserver& observer)
+                {
+                    observer.StateChanged(services::GapState::standby);
+                });
     }
 
     void GapCentralSt::MtuExchange() const


### PR DESCRIPTION
The same event is used for indicating when a connection was successfully established or got cancelled, for this reason the timer to control the initiating state is also used as a flag.