### PR TITLE
feat: allow disable NonMaskableInt_IRQn interrupt

### DIFF
--- a/hal_st/cortex/InterruptCortex.cpp
+++ b/hal_st/cortex/InterruptCortex.cpp
@@ -36,6 +36,8 @@ namespace hal
             }
             else if (irq == -13 /*HardFault_IRQn*/)
                 ;
+            else if (irq == NonMaskableInt_IRQn)
+                ;
             else if (irq == PendSV_IRQn)
                 ;
             else if (irq == SysTick_IRQn)


### PR DESCRIPTION
When the NMI interrupt was enabled, allow it to be disabled.