### PR TITLE
feat: add support for internal ADC channels

### DIFF
--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
@@ -59,35 +59,6 @@ namespace
         return iter->second;
     }
 #endif
-
-    constexpr std::array adcChannel{
-        // STM32F4x header defines ADC_CHANNEL_0 as 0x0u, all others are cast to uint32_t
-        // all other device headers are consistent with all their channel types
-        static_cast<decltype(ADC_CHANNEL_1)>(ADC_CHANNEL_0),
-        ADC_CHANNEL_1,
-        ADC_CHANNEL_2,
-        ADC_CHANNEL_3,
-        ADC_CHANNEL_4,
-        ADC_CHANNEL_5,
-        ADC_CHANNEL_6,
-        ADC_CHANNEL_7,
-        ADC_CHANNEL_8,
-        ADC_CHANNEL_9,
-        ADC_CHANNEL_10,
-        ADC_CHANNEL_11,
-        ADC_CHANNEL_12,
-        ADC_CHANNEL_13,
-#ifdef ADC_CHANNEL_18
-        ADC_CHANNEL_14,
-        ADC_CHANNEL_15,
-        ADC_CHANNEL_16,
-        ADC_CHANNEL_17,
-        ADC_CHANNEL_18,
-#endif
-#ifdef ADC_CHANNEL_19
-        ADC_CHANNEL_19,
-#endif
-    };
 }
 
 namespace hal
@@ -241,7 +212,7 @@ namespace hal
 
     uint32_t AdcStm::Channel(const hal::AnalogPinStm& pin) const
     {
-        return adcChannel[pin.AdcChannel(index + 1)];
+        return pin.AdcChannel(index + 1);
     }
 
     ADC_HandleTypeDef& AdcStm::Handle()

--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.cpp
@@ -23,26 +23,34 @@ extern "C"
 
 namespace
 {
+#if defined(STM32G4) || defined(STM32H5)
+    constexpr std::array irqMap{
 #if defined(STM32G4)
-    constexpr std::array irqMap
-    {
 #if defined(ADC1)
         std::make_pair(1, IRQn_Type::ADC1_2_IRQn), // only ADC1 or ADC2 can be configured to use the single interrupt vector
 #endif
 #if defined(ADC2)
-            std::make_pair(2, IRQn_Type::ADC1_2_IRQn), // only ADC1 or ADC2 can be configured to use the single interrupt vector
+        std::make_pair(2, IRQn_Type::ADC1_2_IRQn), // only ADC1 or ADC2 can be configured to use the single interrupt vector
+#endif
+#else
+#if defined(ADC1)
+        std::make_pair(1, IRQn_Type::ADC1_IRQn),
+#endif
+#if defined(ADC2)
+        std::make_pair(2, IRQn_Type::ADC2_IRQn),
+#endif
 #endif
 
 #if defined(ADC3)
-            std::make_pair(3, IRQn_Type::ADC3_IRQn),
+        std::make_pair(3, IRQn_Type::ADC3_IRQn),
 #endif
 
 #if defined(ADC4)
-            std::make_pair(4, IRQn_Type::ADC4_IRQn),
+        std::make_pair(4, IRQn_Type::ADC4_IRQn),
 #endif
 
 #if defined(ADC5)
-            std::make_pair(5, IRQn_Type::ADC5_IRQn),
+        std::make_pair(5, IRQn_Type::ADC5_IRQn),
 #endif
     };
 
@@ -152,7 +160,7 @@ namespace hal
 #elif defined(STM32WBA)
         , interruptHandler(ADC4_IRQn, [this]()
 #elif defined(STM32H5)
-        , interruptHandler(ADC2_IRQn, [this]()
+        , interruptHandler(LookupIrq(oneBasedIndex), [this]()
 #else
         , interruptHandler(ADC_IRQn, [this]()
 #endif

--- a/hal_st/stm32fxxx/GpioStm.cpp
+++ b/hal_st/stm32fxxx/GpioStm.cpp
@@ -316,8 +316,7 @@ namespace hal
     AnalogPinStm::AnalogPinStm(uint32_t channel)
         : pin(dummyPinStm)
         , channel(channel)
-    {
-    }
+    {}
 
     AnalogPinStm::~AnalogPinStm()
     {

--- a/hal_st/stm32fxxx/GpioStm.cpp
+++ b/hal_st/stm32fxxx/GpioStm.cpp
@@ -91,6 +91,35 @@ namespace hal
             GPIO_MODE_AF_PP,
             GPIO_MODE_AF_OD
         };
+
+        constexpr std::array adcChannel{
+            // STM32F4x header defines ADC_CHANNEL_0 as 0x0u, all others are cast to uint32_t
+            // all other device headers are consistent with all their channel types
+            static_cast<decltype(ADC_CHANNEL_1)>(ADC_CHANNEL_0),
+            ADC_CHANNEL_1,
+            ADC_CHANNEL_2,
+            ADC_CHANNEL_3,
+            ADC_CHANNEL_4,
+            ADC_CHANNEL_5,
+            ADC_CHANNEL_6,
+            ADC_CHANNEL_7,
+            ADC_CHANNEL_8,
+            ADC_CHANNEL_9,
+            ADC_CHANNEL_10,
+            ADC_CHANNEL_11,
+            ADC_CHANNEL_12,
+            ADC_CHANNEL_13,
+#ifdef ADC_CHANNEL_18
+            ADC_CHANNEL_14,
+            ADC_CHANNEL_15,
+            ADC_CHANNEL_16,
+            ADC_CHANNEL_17,
+            ADC_CHANNEL_18,
+#endif
+#ifdef ADC_CHANNEL_19
+            ADC_CHANNEL_19,
+#endif
+        };
     }
 
     DummyPinStm dummyPinStm;
@@ -284,6 +313,12 @@ namespace hal
         pin.ConfigAnalog();
     }
 
+    AnalogPinStm::AnalogPinStm(uint32_t channel)
+        : pin(dummyPinStm)
+        , channel(channel)
+    {
+    }
+
     AnalogPinStm::~AnalogPinStm()
     {
         pin.ResetConfig();
@@ -291,7 +326,9 @@ namespace hal
 
     uint32_t AnalogPinStm::AdcChannel(uint8_t adc) const
     {
-        return pin.AdcChannel(adc);
+        if (channel != 0xffffffff)
+            return channel;
+        return adcChannel[pin.AdcChannel(adc)];
     }
 
     uint32_t AnalogPinStm::DacChannel(uint8_t dac) const

--- a/hal_st/stm32fxxx/GpioStm.hpp
+++ b/hal_st/stm32fxxx/GpioStm.hpp
@@ -197,6 +197,7 @@ namespace hal
     {
     public:
         AnalogPinStm(GpioPinStm& pin);
+        AnalogPinStm(uint32_t channel);
         AnalogPinStm(const AnalogPinStm& other) = delete;
         AnalogPinStm& operator=(const AnalogPinStm& other) = delete;
         ~AnalogPinStm();
@@ -206,6 +207,7 @@ namespace hal
 
     private:
         GpioPinStm& pin;
+        uint32_t channel{ 0xffffffff };
     };
 
     class MultiGpioPinStm


### PR DESCRIPTION
This PR adds support for usage of internal ADC channels by allowing to manually define a AnalogPin channel value.

Additionally, this adds ADC IRQ lookup for `STM32H5` series.