### PR TITLE
chore: Increase InterruptTable size for STM32H5

### DIFF
--- a/hal_st/instantiations/StmEventInfrastructure.hpp
+++ b/hal_st/instantiations/StmEventInfrastructure.hpp
@@ -5,16 +5,26 @@
 #include "hal_st/stm32fxxx/LowPowerStrategyStm.hpp"
 #include "hal_st/stm32fxxx/SystemTickTimerService.hpp"
 #include "infra/event/EventDispatcherWithWeakPtr.hpp"
+#include <cstddef>
 
 namespace main_
 {
+    constexpr std::size_t DefaultInterruptTableSize()
+    {
+#if defined(STM32H5)
+        return 149;
+#else
+        return 128;
+#endif
+    }
+
     struct StmEventInfrastructure
     {
         explicit StmEventInfrastructure(infra::Duration tickDuration = std::chrono::milliseconds(1));
 
         void Run();
 
-        hal::InterruptTable::WithStorage<128> interruptTable;
+        hal::InterruptTable::WithStorage<DefaultInterruptTableSize()> interruptTable;
         infra::EventDispatcherWithWeakPtr::WithSize<50> eventDispatcher;
         hal::GpioStm gpio;
 
@@ -27,7 +37,7 @@ namespace main_
 
         void Run();
 
-        hal::InterruptTable::WithStorage<128> interruptTable;
+        hal::InterruptTable::WithStorage<DefaultInterruptTableSize()> interruptTable;
         hal::LowPowerStrategyStm lowPowerStrategy;
         infra::LowPowerEventDispatcher::WithSize<50> eventDispatcher;
         hal::GpioStm gpio;


### PR DESCRIPTION
For support of all interrupts the interrupt table needs to be increased. 

For STM32H5 that is:
`IRQn_Type::COMP1_IRQn` + 16 = 133 + 16 = 149.