### PR TITLE
feat: provide channel-specific conversion configuration and timer-triggered support

### DIFF
--- a/hal_st/stm32fxxx/AdcDmaMultiChannelStm.hpp
+++ b/hal_st/stm32fxxx/AdcDmaMultiChannelStm.hpp
@@ -25,11 +25,19 @@ namespace hal
         : public AdcMultiChannel
     {
     public:
-        AdcDmaMultiChannelStmBase(infra::MemoryRange<uint16_t> buffer, infra::MemoryRange<AnalogPinStm> analogPins, AdcStm& adc, DmaStm::ReceiveStream& receiveStream);
+        static constexpr std::size_t MaxChannels{ 16 };
+
+        struct OneShot
+        {};
+
+        struct Unlimited
+        {};
+
+        AdcDmaMultiChannelStmBase(infra::MemoryRange<uint16_t> buffer, infra::MemoryRange<AnalogPinStm> analogPins, AdcStm& adc, DmaStm::ReceiveStream& receiveStream, OneShot = {});
+        AdcDmaMultiChannelStmBase(infra::MemoryRange<uint16_t> buffer, infra::MemoryRange<AnalogPinStm> analogPins, AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Unlimited);
 
         void Measure(const infra::Function<void(Samples)>& onDone) override;
-
-        constexpr static std::size_t MaxChannels{ 16 };
+        virtual void Stop();
 
     protected:
         void ConfigureChannels(infra::MemoryRange<const detail::AdcStmChannelConfig> configs);
@@ -38,9 +46,10 @@ namespace hal
         infra::MemoryRange<uint16_t> buffer;
         infra::MemoryRange<AnalogPinStm> analogPins;
         AdcStm& adc;
-        ReceiveDmaChannel dmaStream;
-        infra::AutoResetFunction<void(Samples)> onDone;
+        infra::Variant<ReceiveDmaChannel, CircularReceiveDmaChannel> dmaStream;
+        infra::Function<void(Samples)> onDone;
 
+        void Initialize();
         void TransferDone();
     };
 
@@ -79,7 +88,10 @@ namespace hal
     template<class T>
     concept PinConfig = IsAnyOf<T, AdcPinConfig<GpioPinStm&>, AdcPinConfig<uint32_t>, AdcPinConfig<unsigned long>>;
 
-    template<std::size_t Channels>
+    template<class T>
+    concept DmaMode = IsAnyOf<T, AdcDmaMultiChannelStmBase::OneShot, AdcDmaMultiChannelStmBase::Unlimited>;
+
+    template<std::size_t Channels, DmaMode Mode = AdcDmaMultiChannelStmBase::OneShot>
     class AdcDmaMultiChannelStm : public AdcDmaMultiChannelStmBase
     {
     public:
@@ -99,31 +111,46 @@ namespace hal
         void Configure(PinConfigs&&... pinConfigs);
     };
 
+    template<std::size_t Channels>
+    class AdcDmaMultiChannelStmTriggeredByTimer final
+        : private AdcTimerTriggeredBase
+        , public AdcDmaMultiChannelStm<Channels, AdcDmaMultiChannelStmBase::Unlimited>
+    {
+    public:
+        template<AdcPin... Pins>
+        explicit AdcDmaMultiChannelStmTriggeredByTimer(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing, Pins&&... pins);
+        template<PinConfig... PinConfigs>
+        explicit AdcDmaMultiChannelStmTriggeredByTimer(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing, PinConfigs&&... pinConfigs);
+
+        void Measure(const infra::Function<void(AdcMultiChannel::Samples)>& onDone) override;
+        void Stop() override;
+    };
+
     ////    Implementation    ////
 
-    template<std::size_t Channels>
+    template<std::size_t Channels, DmaMode Mode>
     template<AdcPin... Pins>
-    AdcDmaMultiChannelStm<Channels>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Pins&&... pins)
-        : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream }
+    AdcDmaMultiChannelStm<Channels, Mode>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Pins&&... pins)
+        : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream, Mode{} }
         , pinStorage{ std::forward<Pins>(pins)... }
     {
         static_assert(sizeof...(Pins) == Channels, "Number of Pins and Channels not matching");
         Configure();
     }
 
-    template<std::size_t Channels>
+    template<std::size_t Channels, DmaMode Mode>
     template<PinConfig... PinConfigs>
-    AdcDmaMultiChannelStm<Channels>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, PinConfigs&&... pinConfigs)
-        : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream }
+    AdcDmaMultiChannelStm<Channels, Mode>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, PinConfigs&&... pinConfigs)
+        : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream, Mode{} }
         , pinStorage{ (AnalogPinStm{ pinConfigs.pin })... }
     {
         static_assert(sizeof...(PinConfigs) == Channels, "Number of Pins and Channels not matching");
         Configure(std::forward<PinConfigs>(pinConfigs)...);
     }
 
-    template<std::size_t Channels>
+    template<std::size_t Channels, DmaMode Mode>
     template<PinConfig... PinConfigs>
-    void AdcDmaMultiChannelStm<Channels>::Configure(PinConfigs&&... pinConfigs)
+    void AdcDmaMultiChannelStm<Channels, Mode>::Configure(PinConfigs&&... pinConfigs)
     {
         if constexpr (sizeof...(PinConfigs) == 0)
         {
@@ -135,6 +162,38 @@ namespace hal
             std::array configs{ (detail::AdcStmChannelConfig{ pinConfigs.samplingTime, pinConfigs.differential })... };
             ConfigureChannels(configs);
         }
+    }
+
+    template<std::size_t Channels>
+    template<AdcPin... Pins>
+    AdcDmaMultiChannelStmTriggeredByTimer<Channels>::AdcDmaMultiChannelStmTriggeredByTimer(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing, Pins&&... pins)
+        : AdcTimerTriggeredBase(adc, oneBasedTimerIndex, timing)
+        , AdcDmaMultiChannelStm<Channels, AdcDmaMultiChannelStmBase::Unlimited>(adc, receiveStream, std::forward<Pins>(pins)...)
+    {
+        ReconfigureTrigger();
+    }
+
+    template<std::size_t Channels>
+    template<PinConfig... PinConfigs>
+    AdcDmaMultiChannelStmTriggeredByTimer<Channels>::AdcDmaMultiChannelStmTriggeredByTimer(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing, PinConfigs&&... pinConfigs)
+        : AdcTimerTriggeredBase(adc, oneBasedTimerIndex, timing)
+        , AdcDmaMultiChannelStm<Channels, AdcDmaMultiChannelStmBase::Unlimited>(adc, receiveStream, std::forward<PinConfigs>(pinConfigs)...)
+    {
+        ReconfigureTrigger();
+    }
+
+    template<std::size_t Channels>
+    void AdcDmaMultiChannelStmTriggeredByTimer<Channels>::Measure(const infra::Function<void(AdcMultiChannel::Samples)>& onDone)
+    {
+        StartTimer();
+        AdcDmaMultiChannelStmBase::Measure(onDone);
+    }
+
+    template<std::size_t Channels>
+    void AdcDmaMultiChannelStmTriggeredByTimer<Channels>::Stop()
+    {
+        AdcDmaMultiChannelStmBase::Stop();
+        StopTimer();
     }
 }
 

--- a/hal_st/stm32fxxx/AdcDmaMultiChannelStm.hpp
+++ b/hal_st/stm32fxxx/AdcDmaMultiChannelStm.hpp
@@ -2,31 +2,37 @@
 #define HAL_ST_ADC_DMA_MULTI_CHANNEL_HPP
 
 #include "hal/interfaces/AdcMultiChannel.hpp"
+#include "hal_st/stm32fxxx/AdcTimerTriggeredBase.hpp"
 #include "hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp"
 #include "hal_st/stm32fxxx/DmaStm.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
-#include "infra/util/AutoResetFunction.hpp"
+#include "hal_st/stm32fxxx/TimerStm.hpp"
+#include "infra/util/Function.hpp"
+#include "infra/util/MemoryRange.hpp"
+#include "infra/util/Variant.hpp"
 #include <array>
+#include <concepts>
 #include <cstddef>
+#include <cstdint>
+#include <utility>
 
 /// @brief This ADC implementation supports multiple channels with DMA transfer and software trigger.
-///        DMA transfer is one shot mode.
+///        DMA transfer is either one shot or unlimited mode. In unlimited mode, ADC converion will run continuously until Stop() is called.
+///        The conversion callback is executed from the interrupt scope. The user can decide to handle it later using the EventDispatcher.
 namespace hal
 {
     class AdcDmaMultiChannelStmBase
         : public AdcMultiChannel
     {
     public:
-        AdcDmaMultiChannelStmBase(
-            infra::MemoryRange<uint16_t> buffer, infra::MemoryRange<AnalogPinStm> analogPins, AdcStm& adc,
-            DmaStm::ReceiveStream& receiveStream);
+        AdcDmaMultiChannelStmBase(infra::MemoryRange<uint16_t> buffer, infra::MemoryRange<AnalogPinStm> analogPins, AdcStm& adc, DmaStm::ReceiveStream& receiveStream);
 
         void Measure(const infra::Function<void(Samples)>& onDone) override;
 
         constexpr static std::size_t MaxChannels{ 16 };
 
     protected:
-        void ConfigureChannels();
+        void ConfigureChannels(infra::MemoryRange<const detail::AdcStmChannelConfig> configs);
 
     private:
         infra::MemoryRange<uint16_t> buffer;
@@ -38,33 +44,98 @@ namespace hal
         void TransferDone();
     };
 
+    template<class T>
+    concept AdcPin = std::constructible_from<AnalogPinStm, T>;
+
+    template<AdcPin Pin>
+    struct AdcPinConfig
+        : detail::AdcStmChannelConfig
+    {
+        Pin pin;
+
+        AdcPinConfig(Pin pin)
+            : AdcStmChannelConfig{}
+            , pin(pin)
+        {}
+
+        AdcPinConfig(Pin pin, uint32_t samplingTime)
+            : AdcStmChannelConfig{ samplingTime }
+            , pin(pin)
+        {}
+
+        AdcPinConfig(Pin pin, uint32_t samplingTime, bool differential)
+            : AdcStmChannelConfig{ samplingTime, differential }
+            , pin(pin)
+        {}
+    };
+
+    AdcPinConfig(GpioPinStm pin, uint32_t samplingTime, bool differential) -> AdcPinConfig<GpioPinStm&>;
+    AdcPinConfig(GpioPinStm pin, uint32_t samplingTime) -> AdcPinConfig<GpioPinStm&>;
+    AdcPinConfig(GpioPinStm pin) -> AdcPinConfig<GpioPinStm&>;
+
+    template<typename T, typename... U>
+    concept IsAnyOf = (std::same_as<T, U> || ...);
+
+    template<class T>
+    concept PinConfig = IsAnyOf<T, AdcPinConfig<GpioPinStm&>, AdcPinConfig<uint32_t>, AdcPinConfig<unsigned long>>;
+
     template<std::size_t Channels>
     class AdcDmaMultiChannelStm : public AdcDmaMultiChannelStmBase
     {
     public:
         static_assert(Channels <= MaxChannels, "Number of Channels not supported");
 
-        template<class... Pins>
+        template<AdcPin... Pins>
         explicit AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Pins&&... pins);
+
+        template<PinConfig... PinConfigs>
+        explicit AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, PinConfigs&&... pinConfigs);
 
     private:
         std::array<uint16_t, Channels> bufferStorage{};
         std::array<AnalogPinStm, Channels> pinStorage;
+
+        template<PinConfig... PinConfigs>
+        void Configure(PinConfigs&&... pinConfigs);
     };
 
     ////    Implementation    ////
 
     template<std::size_t Channels>
-    template<class... Pins>
-    AdcDmaMultiChannelStm<Channels>::AdcDmaMultiChannelStm(
-        AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Pins&&... pins)
+    template<AdcPin... Pins>
+    AdcDmaMultiChannelStm<Channels>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, Pins&&... pins)
         : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream }
         , pinStorage{ std::forward<Pins>(pins)... }
     {
         static_assert(sizeof...(Pins) == Channels, "Number of Pins and Channels not matching");
-        ConfigureChannels();
+        Configure();
     }
 
+    template<std::size_t Channels>
+    template<PinConfig... PinConfigs>
+    AdcDmaMultiChannelStm<Channels>::AdcDmaMultiChannelStm(AdcStm& adc, DmaStm::ReceiveStream& receiveStream, PinConfigs&&... pinConfigs)
+        : AdcDmaMultiChannelStmBase{ bufferStorage, pinStorage, adc, receiveStream }
+        , pinStorage{ (AnalogPinStm{ pinConfigs.pin })... }
+    {
+        static_assert(sizeof...(PinConfigs) == Channels, "Number of Pins and Channels not matching");
+        Configure(std::forward<PinConfigs>(pinConfigs)...);
+    }
+
+    template<std::size_t Channels>
+    template<PinConfig... PinConfigs>
+    void AdcDmaMultiChannelStm<Channels>::Configure(PinConfigs&&... pinConfigs)
+    {
+        if constexpr (sizeof...(PinConfigs) == 0)
+        {
+            std::array<detail::AdcStmChannelConfig, Channels> configs{};
+            ConfigureChannels(configs);
+        }
+        else
+        {
+            std::array configs{ (detail::AdcStmChannelConfig{ pinConfigs.samplingTime, pinConfigs.differential })... };
+            ConfigureChannels(configs);
+        }
+    }
 }
 
 #endif

--- a/hal_st/stm32fxxx/AdcTimerTriggeredBase.cpp
+++ b/hal_st/stm32fxxx/AdcTimerTriggeredBase.cpp
@@ -1,0 +1,155 @@
+#include "hal_st/stm32fxxx/AdcTimerTriggeredBase.hpp"
+#include "hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp"
+#include DEVICE_HEADER
+
+#if defined(STM32F7)
+#include "stm32f7xx_ll_adc.h"
+#endif
+
+#if defined(HAS_PERIPHERAL_TIMER)
+
+namespace
+{
+    constexpr unsigned long TriggerUnsupported{ 255 };
+
+    constexpr std::array triggers = {
+#if defined(ADC_EXTERNALTRIGCONV_T1_TRGO)
+        ADC_EXTERNALTRIGCONV_T1_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T1_TRGO)
+        ADC_EXTERNALTRIG_T1_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T1_TRGO2)
+        ADC_EXTERNALTRIG_T1_TRGO2,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T2_TRGO)
+        ADC_EXTERNALTRIGCONV_T2_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T2_TRGO)
+        ADC_EXTERNALTRIG_T2_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T3_TRGO)
+        ADC_EXTERNALTRIGCONV_T3_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T3_TRGO)
+        ADC_EXTERNALTRIG_T3_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T4_TRGO)
+        ADC_EXTERNALTRIGCONV_T4_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T4_TRGO)
+        ADC_EXTERNALTRIG_T4_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T5_TRGO)
+        ADC_EXTERNALTRIGCONV_T5_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T5_TRGO)
+        ADC_EXTERNALTRIG_T5_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T6_TRGO)
+        ADC_EXTERNALTRIGCONV_T6_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T6_TRGO)
+        ADC_EXTERNALTRIG_T6_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T7_TRGO)
+        ADC_EXTERNALTRIGCONV_T7_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T7_TRGO)
+        ADC_EXTERNALTRIG_T7_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T8_TRGO)
+        ADC_EXTERNALTRIGCONV_T8_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T8_TRGO)
+        ADC_EXTERNALTRIG_T8_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T9_TRGO)
+        ADC_EXTERNALTRIGCONV_T9_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T9_TRGO)
+        ADC_EXTERNALTRIG_T9_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T11_TRGO)
+        ADC_EXTERNALTRIGCONV_T11_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T11_TRGO)
+        ADC_EXTERNALTRIG_T11_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T12_TRGO)
+        ADC_EXTERNALTRIGCONV_T12_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T12_TRGO)
+        ADC_EXTERNALTRIG_T12_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T13_TRGO)
+        ADC_EXTERNALTRIGCONV_T13_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T13_TRGO)
+        ADC_EXTERNALTRIG_T13_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T14_TRGO)
+        ADC_EXTERNALTRIGCONV_T14_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T14_TRGO)
+        ADC_EXTERNALTRIG_T14_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+#if defined(ADC_EXTERNALTRIGCONV_T15_TRGO)
+        ADC_EXTERNALTRIGCONV_T15_TRGO,
+#elif defined(ADC_EXTERNALTRIG_T15_TRGO)
+        ADC_EXTERNALTRIG_T15_TRGO,
+#else
+        TriggerUnsupported,
+#endif
+    };
+
+    uint32_t FindTrigger(uint8_t index)
+    {
+        assert(index < triggers.size());
+        assert(triggers[index] != TriggerUnsupported);
+        return triggers[index];
+    }
+}
+
+namespace hal
+{
+    AdcTimerTriggeredBase::AdcTimerTriggeredBase(AdcStm& adc, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing)
+        : adc(adc)
+        , timer(oneBasedTimerIndex, timing, { TimerBaseStm::CounterMode::up, infra::MakeOptional<TimerBaseStm::Trigger>({ TimerBaseStm::Trigger::TriggerOutput::update, false }) })
+        , timerIndex(oneBasedTimerIndex - 1)
+    {}
+
+    void AdcTimerTriggeredBase::ReconfigureTrigger()
+    {
+        HAL_ADC_Stop(&adc.Handle());
+
+        LL_ADC_REG_SetTriggerSource(adc.Handle().Instance, FindTrigger(timerIndex));
+#if defined(ADC_CFGR1_EXTEN) || defined(ADC_CFGR_EXTEN)
+        LL_ADC_REG_SetTriggerEdge(adc.Handle().Instance, ADC_EXTERNALTRIGCONVEDGE_RISING);
+#endif
+    }
+
+    void AdcTimerTriggeredBase::StartTimer()
+    {
+        timer.Start();
+    }
+
+    void AdcTimerTriggeredBase::StopTimer()
+    {
+        timer.Stop();
+    }
+}
+
+#endif

--- a/hal_st/stm32fxxx/AdcTimerTriggeredBase.hpp
+++ b/hal_st/stm32fxxx/AdcTimerTriggeredBase.hpp
@@ -1,0 +1,30 @@
+#ifndef HAL_ST_ADC_TIMER_TRIGGERED_BASE_HPP
+#define HAL_ST_ADC_TIMER_TRIGGERED_BASE_HPP
+
+#include "hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp"
+#include "hal_st/stm32fxxx/TimerStm.hpp"
+#include <cstdint>
+
+#if defined(HAS_PERIPHERAL_TIMER)
+
+namespace hal
+{
+    class AdcTimerTriggeredBase
+    {
+    protected:
+        AdcTimerTriggeredBase(AdcStm& adc, uint8_t oneBasedTimerIndex, TimerBaseStm::Timing timing);
+
+        void ReconfigureTrigger();
+        void StartTimer();
+        void StopTimer();
+
+    private:
+        AdcStm& adc;
+        FreeRunningTimerStm timer;
+        uint8_t timerIndex;
+    };
+}
+
+#endif
+
+#endif // HAL_ST_ADC_TIMER_TRIGGERED_BASE_HPP

--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
@@ -70,9 +70,6 @@ namespace hal
         Config config;
     };
 
-    class AdcTriggeredByTimerWithDma;
-    class AdcDmaMultiChannelStmBase;
-
     class AdcStm
     {
     public:
@@ -81,7 +78,6 @@ namespace hal
         explicit AdcStm(uint8_t adcIndex, const Config& config = Config());
         ~AdcStm();
 
-    protected:
         uint32_t Channel(const hal::AnalogPinStm& pin) const;
         ADC_HandleTypeDef& Handle();
 
@@ -92,8 +88,6 @@ namespace hal
     private:
         friend class AnalogToDigitalPinImplStm;
         friend class AnalogToDigitalInternalTemperatureStm;
-        friend class AdcTriggeredByTimerWithDma;
-        friend class AdcDmaMultiChannelStmBase;
 
         uint8_t index;
         ADC_HandleTypeDef handle{};

--- a/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
+++ b/hal_st/stm32fxxx/AnalogToDigitalPinStm.hpp
@@ -25,6 +25,7 @@ namespace hal
 #else
             uint32_t samplingTime{ ADC_SAMPLETIME_3CYCLES };
 #endif
+            bool differential{ false };
         };
 
         struct AdcStmConfig

--- a/hal_st/stm32fxxx/CMakeLists.txt
+++ b/hal_st/stm32fxxx/CMakeLists.txt
@@ -18,6 +18,8 @@ target_link_libraries(hal_st.stm32fxxx PUBLIC
 target_sources(hal_st.stm32fxxx PRIVATE
     AnalogToDigitalPinStm.cpp
     AnalogToDigitalPinStm.hpp
+    AdcTimerTriggeredBase.cpp
+    AdcTimerTriggeredBase.hpp
     BackupRamStm.cpp
     BackupRamStm.hpp
     CanStm.cpp


### PR DESCRIPTION
Provide channel-specific conversion configuration for the `AdcDmaMultiChannelStm`.

Configuration will look like this:
```cpp
hal::AdcDmaMultiChannelStm<2> multiChannel(adc, receiveStream, 
        hal::AdcPinConfig{positivePin, ADC_SAMPLETIME_47CYCLES_5, true},
        hal::AdcPinConfig{ADC_CHANNEL_TEMPSENSOR, ADC_SAMPLETIME_47CYCLES_5});
```

Additionally add support for timer-triggered ADC conversion.