### PR TITLE
fix: revert "fix: GPDMA channel abort sequence (#555)"

### DIFF
--- a/hal_st/stm32fxxx/DmaStm.cpp
+++ b/hal_st/stm32fxxx/DmaStm.cpp
@@ -30,24 +30,25 @@ namespace hal
             std::array{ DMA2_Stream0_IRQn, DMA2_Stream1_IRQn, DMA2_Stream2_IRQn, DMA2_Stream3_IRQn, DMA2_Stream4_IRQn, DMA2_Stream5_IRQn, DMA2_Stream6_IRQn, DMA2_Stream7_IRQn },
         };
 
-        const std::array dmaChannel{
+        const std::array dmaChannel
+        {
             DMA_CHANNEL_0,
-            DMA_CHANNEL_1,
-            DMA_CHANNEL_2,
-            DMA_CHANNEL_3,
-            DMA_CHANNEL_4,
-            DMA_CHANNEL_5,
-            DMA_CHANNEL_6,
-            DMA_CHANNEL_7,
+                DMA_CHANNEL_1,
+                DMA_CHANNEL_2,
+                DMA_CHANNEL_3,
+                DMA_CHANNEL_4,
+                DMA_CHANNEL_5,
+                DMA_CHANNEL_6,
+                DMA_CHANNEL_7,
 #if defined(DMA_CHANNEL_15)
-            DMA_CHANNEL_8,
-            DMA_CHANNEL_9,
-            DMA_CHANNEL_10,
-            DMA_CHANNEL_11,
-            DMA_CHANNEL_12,
-            DMA_CHANNEL_13,
-            DMA_CHANNEL_14,
-            DMA_CHANNEL_15,
+                DMA_CHANNEL_8,
+                DMA_CHANNEL_9,
+                DMA_CHANNEL_10,
+                DMA_CHANNEL_11,
+                DMA_CHANNEL_12,
+                DMA_CHANNEL_13,
+                DMA_CHANNEL_14,
+                DMA_CHANNEL_15,
 #endif
         };
 
@@ -577,15 +578,11 @@ namespace hal
     {
         auto streamRegister = DmaChannel[dmaIndex][streamIndex];
 #ifdef GPDMA1
-        streamRegister->CCR |= DMA_CCR_SUSP;
-        if ((streamRegister->CCR & DMA_CCR_EN) == DMA_CCR_EN)
-        {
-            while ((streamRegister->CSR & DMA_CSR_SUSPF) == 0)
-                ;
-        }
-        streamRegister->CCR |= DMA_CCR_RESET;
+        streamRegister->CCR |= (DMA_CCR_SUSP | DMA_CCR_RESET);
 #endif
-#if defined(DMA_SxCR_EN)
+#if defined(DMA_CCR_EN)
+        streamRegister->CCR &= ~DMA_CCR_EN;
+#else
         streamRegister->CR &= ~DMA_SxCR_EN;
 #endif
     }


### PR DESCRIPTION
This commit breaks downstream. Not sure of the root cause yet, but reverting to unblock use of halst main downstream.

This reverts commit dad8a32c74b204e25049cac42612125aea9bef99 