### PR TITLE
fix: GPDMA channel abort sequence

### DIFF
--- a/hal_st/stm32fxxx/DmaStm.cpp
+++ b/hal_st/stm32fxxx/DmaStm.cpp
@@ -30,25 +30,24 @@ namespace hal
             std::array{ DMA2_Stream0_IRQn, DMA2_Stream1_IRQn, DMA2_Stream2_IRQn, DMA2_Stream3_IRQn, DMA2_Stream4_IRQn, DMA2_Stream5_IRQn, DMA2_Stream6_IRQn, DMA2_Stream7_IRQn },
         };
 
-        const std::array dmaChannel
-        {
+        const std::array dmaChannel{
             DMA_CHANNEL_0,
-                DMA_CHANNEL_1,
-                DMA_CHANNEL_2,
-                DMA_CHANNEL_3,
-                DMA_CHANNEL_4,
-                DMA_CHANNEL_5,
-                DMA_CHANNEL_6,
-                DMA_CHANNEL_7,
+            DMA_CHANNEL_1,
+            DMA_CHANNEL_2,
+            DMA_CHANNEL_3,
+            DMA_CHANNEL_4,
+            DMA_CHANNEL_5,
+            DMA_CHANNEL_6,
+            DMA_CHANNEL_7,
 #if defined(DMA_CHANNEL_15)
-                DMA_CHANNEL_8,
-                DMA_CHANNEL_9,
-                DMA_CHANNEL_10,
-                DMA_CHANNEL_11,
-                DMA_CHANNEL_12,
-                DMA_CHANNEL_13,
-                DMA_CHANNEL_14,
-                DMA_CHANNEL_15,
+            DMA_CHANNEL_8,
+            DMA_CHANNEL_9,
+            DMA_CHANNEL_10,
+            DMA_CHANNEL_11,
+            DMA_CHANNEL_12,
+            DMA_CHANNEL_13,
+            DMA_CHANNEL_14,
+            DMA_CHANNEL_15,
 #endif
         };
 
@@ -578,9 +577,14 @@ namespace hal
     {
         auto streamRegister = DmaChannel[dmaIndex][streamIndex];
 #ifdef GPDMA1
-        streamRegister->CCR |= (DMA_CCR_SUSP | DMA_CCR_RESET);
-#endif
-#if defined(DMA_CCR_EN)
+        streamRegister->CCR |= DMA_CCR_SUSP;
+        if ((streamRegister->CCR & DMA_CCR_EN) == DMA_CCR_EN)
+        {
+            while ((streamRegister->CSR & DMA_CSR_SUSPF) == 0)
+                ;
+        }
+        streamRegister->CCR |= DMA_CCR_RESET;
+#elif defined(DMA_CCR_EN)
         streamRegister->CCR &= ~DMA_CCR_EN;
 #else
         streamRegister->CR &= ~DMA_SxCR_EN;


### PR DESCRIPTION
Fix GPDMA channel abort sequence

For aborting a continuous GPDMA transfer with a circular buffering or a double buffering, the software can abort, on its own, a still active channel with the following sequence:
1. Suspend the channel
2. Wait until it was effectively supended
3. Reset the channel (which will reset the EN bit)

Ignoring this sequence can cause the channel not being able to start again when an DMA transfer was active while setting the RESET bit.

This includes the fix for STM32WB55 for which in the first run the `#elif` was missing