### PR TITLE
feat: evaluate PHY Auto-Negotiation ability

### DIFF
--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -109,8 +109,8 @@ namespace hal
         sequencer.Execute([this]()
             {
                 uint16_t status = ReadPhyRegister(phyBasicStatusRegister);
-                autoNego = infra::IsBitSet(status, phyBsrAutoNegotiationAbility);
-                if (autoNego)
+                autoNegotiation = infra::IsBitSet(status, phyBsrAutoNegotiationAbility);
+                if (autoNegotiation)
                     WritePhyRegister(phyBasicControlRegister, infra::Bit<uint16_t>(phyBcrAutoNegotiationEnable));
             });
     }
@@ -120,8 +120,8 @@ namespace hal
         sequencer.Execute([this]()
             {
                 uint16_t status = ReadPhyRegister(phyBasicStatusRegister);
-                bool autoNegoComplete = autoNego ? infra::IsBitSet(status, phyBsrAutoNegotiationComplete) : true;
-                bool newLinkUp = infra::IsBitSet(status, phyBsrLinkUp) && autoNegoComplete;
+                bool autoNegotiationComplete = autoNegotiation ? infra::IsBitSet(status, phyBsrAutoNegotiationComplete) : true;
+                bool newLinkUp = infra::IsBitSet(status, phyBsrLinkUp) && autoNegotiationComplete;
 
                 if (newLinkUp != linkUp)
                 {
@@ -129,7 +129,7 @@ namespace hal
 
                     if (linkUp)
                     {
-                        LinkSpeed speed = autoNego ? GetLinkSpeedNegotiated() : GetLinkSpeedLocal();
+                        LinkSpeed speed = autoNegotiation ? GetLinkSpeedNegotiated() : GetLinkSpeedLocal();
                         GetObserver().LinkUp(speed);
                     }
                     else

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -25,7 +25,9 @@ namespace hal
         void SetMiiClockRange();
         void ResetPhy();
         void DetectLink();
-        uint16_t ReadPhyRegister(uint16_t reg);
+        LinkSpeed GetLinkSpeedNegotiated() const;
+        LinkSpeed GetLinkSpeedLocal() const;
+        uint16_t ReadPhyRegister(uint16_t reg) const;
         void WritePhyRegister(uint16_t reg, uint16_t value);
         void Delay(infra::Duration duration);
 
@@ -42,10 +44,11 @@ namespace hal
         uint16_t phyAddress;
 
         infra::Sequencer sequencer;
-        uint32_t phyRegisterValue;
+        uint32_t phyControlRegisterValue;
         infra::TimerSingleShot delayTimer;
         infra::Duration delay;
 
+        bool autoNego = false;
         bool linkUp = false;
 
         static const uint16_t phyBasicControlRegister = 0;
@@ -56,10 +59,11 @@ namespace hal
         static const uint16_t phyBcrDuplexMode = 8;
         static const uint16_t phyBcrRestartAutoNegotiation = 9;
         static const uint16_t phyBcrAutoNegotiationEnable = 12;
-        static const uint16_t phyBcrSpeedSelect = 13;
+        static const uint16_t phyBcrSpeedSelectLsb = 13;
         static const uint16_t phyBcrReset = 15;
 
         static const uint16_t phyBsrLinkUp = 2;
+        static const uint16_t phyBsrAutoNegotiationAbility = 3;
         static const uint16_t phyBsrAutoNegotiationComplete = 5;
 
         static const uint16_t phyAnlpaHalfDuplex10MHz = 5;

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -48,7 +48,7 @@ namespace hal
         infra::TimerSingleShot delayTimer;
         infra::Duration delay;
 
-        bool autoNego = false;
+        bool autoNegotiation = false;
         bool linkUp = false;
 
         static const uint16_t phyBasicControlRegister = 0;


### PR DESCRIPTION
If the PHY is not able to perform Auto-Negotiation,
select the SpeedLink based on the Control Register