### PR TITLE
feat: Extend GapCentralST's SetSecurityMode

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -276,27 +276,14 @@ namespace hal
             });
     }
 
-    void GapCentralSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
+    GapSt::SecureConnection GapCentralSt::SecurityLevelToSecureConnection(services::GapPairing::SecurityLevel level) const
     {
-        assert(mode == services::GapPairing::SecurityMode::mode1);
-
-        enum class SecureConnection : uint8_t
-        {
-            notSupported = 0,
-            optional = 1,
-            mandatory
-        };
-
-        SecureConnection secureConnectionSupport = SecureConnection::optional;
-
         if (level == services::GapPairing::SecurityLevel::level1)
-            secureConnectionSupport = SecureConnection::notSupported;
+            return SecureConnection::notSupported;
         else if (level == services::GapPairing::SecurityLevel::level4)
-            secureConnectionSupport = SecureConnection::mandatory;
+            return SecureConnection::mandatory;
 
-        uint8_t mitmMode = (level == services::GapPairing::SecurityLevel::level3 || level == services::GapPairing::SecurityLevel::level4) ? 1 : 0;
-
-        aci_gap_set_authentication_requirement(bondingMode, mitmMode, static_cast<uint8_t>(secureConnectionSupport), keypressNotificationSupport, 16, 16, 0, 111111, GAP_PUBLIC_ADDR);
+        return SecureConnection::optional;
     }
 
     void GapCentralSt::Initialize(const GapService& gapService)

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -276,7 +276,7 @@ namespace hal
             });
     }
 
-    void GapSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
+    void GapCentralSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
     {
         assert(mode == services::GapPairing::SecurityMode::mode1);
 

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -287,14 +287,12 @@ namespace hal
             mandatory
         };
 
-        SecureConnection secureConnectionSupport;
+        SecureConnection secureConnectionSupport = SecureConnection::optional;
 
         if (level == services::GapPairing::SecurityLevel::level1)
             secureConnectionSupport = SecureConnection::notSupported;
         else if (level == services::GapPairing::SecurityLevel::level4)
             secureConnectionSupport = SecureConnection::mandatory;
-        else
-            secureConnectionSupport = SecureConnection::optional;
 
         uint8_t mitmMode = (level == services::GapPairing::SecurityLevel::level3 || level == services::GapPairing::SecurityLevel::level4) ? 1 : 0;
 

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -288,6 +288,31 @@ namespace hal
             });
     }
 
+    void GapSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
+    {
+        assert(mode == services::GapPairing::SecurityMode::mode1);
+
+        enum class SecureConnection : uint8_t
+        {
+            notSupported = 0,
+            optional = 1,
+            mandatory
+        };
+
+        SecureConnection secureConnectionSupport;
+
+        if (level == services::GapPairing::SecurityLevel::level1)
+            secureConnectionSupport = SecureConnection::notSupported;
+        else if (level == services::GapPairing::SecurityLevel::level4)
+            secureConnectionSupport = SecureConnection::mandatory;
+        else
+            secureConnectionSupport = SecureConnection::optional;
+
+        uint8_t mitmMode = (level == services::GapPairing::SecurityLevel::level3 || level == services::GapPairing::SecurityLevel::level4) ? 1 : 0;
+
+        aci_gap_set_authentication_requirement(bondingMode, mitmMode, static_cast<uint8_t>(secureConnectionSupport), keypressNotificationSupport, 16, 16, 0, 111111, GAP_PUBLIC_ADDR);
+    }
+
     void GapCentralSt::Initialize(const GapService& gapService)
     {
         uint16_t gapServiceHandle, gapDevNameCharHandle, gapAppearanceCharHandle;

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -27,9 +27,10 @@ namespace hal
         // Implementation of GapPairing
         void PairAndBond() override;
         void AllowPairing(bool allow) override;
-        void SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level) override;
 
     protected:
+        [[nodiscard]] SecureConnection SecurityLevelToSecureConnection(services::GapPairing::SecurityLevel level) const override;
+
         void HandleHciDisconnectEvent(const hci_disconnection_complete_event_rp0& event) override;
         void HandleHciLeAdvertisingReportEvent(const hci_le_advertising_report_event_rp0& event) override;
         void HandleHciLeConnectionCompleteEvent(const hci_le_connection_complete_event_rp0& event) override;

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -27,6 +27,7 @@ namespace hal
         // Implementation of GapPairing
         void PairAndBond() override;
         void AllowPairing(bool allow) override;
+        void SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level) override;
 
     protected:
         void HandleHciDisconnectEvent(hci_event_pckt& eventPacket) override;

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -97,18 +97,16 @@ namespace hal
         aci_gap_send_pairing_req(connectionContext.connectionHandle, NO_BONDING);
     }
 
+    GapSt::SecureConnection GapSt::SecurityLevelToSecureConnection(services::GapPairing::SecurityLevel level) const
+    {
+        return (level == services::GapPairing::SecurityLevel::level4) ? SecureConnection::mandatory : SecureConnection::optional;
+    }
+
     void GapSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
     {
         assert(mode == services::GapPairing::SecurityMode::mode1);
 
-        enum class SecureConnection : uint8_t
-        {
-            notSupported = 0,
-            optional = 1,
-            mandatory
-        };
-
-        SecureConnection secureConnectionSupport = (level == services::GapPairing::SecurityLevel::level4) ? SecureConnection::mandatory : SecureConnection::optional;
+        SecureConnection secureConnectionSupport = SecurityLevelToSecureConnection(level);
         uint8_t mitmMode = (level == services::GapPairing::SecurityLevel::level3 || level == services::GapPairing::SecurityLevel::level4) ? 1 : 0;
 
         aci_gap_set_authentication_requirement(bondingMode, mitmMode, static_cast<uint8_t>(secureConnectionSupport), keypressNotificationSupport, 16, 16, 0, 111111, GAP_PUBLIC_ADDR);

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -55,6 +55,13 @@ namespace hal
         void NumericComparisonConfirm(bool accept) override;
 
     protected:
+        enum class SecureConnection : uint8_t
+        {
+            notSupported = 0,
+            optional = 1,
+            mandatory
+        };
+
         GapSt(HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration);
 
         virtual void HandleHciDisconnectEvent(const hci_disconnection_complete_event_rp0& event);
@@ -72,6 +79,8 @@ namespace hal
         virtual void HandleGattCompleteEvent(const aci_gatt_proc_complete_event_rp0& event) {};
         virtual void HandleL2capConnectionUpdateRequestEvent(const aci_l2cap_connection_update_req_event_rp0& event) {};
         virtual void HandleMtuExchangeResponseEvent(const aci_att_exchange_mtu_resp_event_rp0& event);
+
+        [[nodiscard]] virtual SecureConnection SecurityLevelToSecureConnection(services::GapPairing::SecurityLevel level) const;
 
         void SetAddress(const MacAddress& address, services::GapDeviceAddressType addressType);
 

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -93,7 +93,7 @@ namespace hal
         GapCentralSt::PairAndBond();
     }
 
-    void TracingGapCentralSt::SetSecurityMode(SecurityMode mode, SecurityLevel level)
+    void TracingGapCentralSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
     {
         tracer.Trace() << "TracingGapCentralSt::SetSecurityMode";
         GapCentralSt::SetSecurityMode(mode, level);

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -93,7 +93,7 @@ namespace hal
         GapCentralSt::PairAndBond();
     }
 
-    void TracingGapCentralSt::SetSecurityMode(services::GapPairing::SecurityMode mode, services::GapPairing::SecurityLevel level)
+    void TracingGapCentralSt::SetSecurityMode(SecurityMode mode, SecurityLevel level)
     {
         tracer.Trace() << "TracingGapCentralSt::SetSecurityMode";
         GapCentralSt::SetSecurityMode(mode, level);


### PR DESCRIPTION
ST Centrals support 'not supported' 'mandatory' and 'optional' secureConnectionSupport levels.

This PR aims to add the 'not supported' mode.