### PR TITLE
fix: implement retry mechanism for Gatt WriteWithoutResponse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        a488c4246e482e296968607e83736aebe24580c0 # unreleased
+        GIT_TAG        d6b3dc53f0e6bc277e96515dc85b3f95a80da9f0 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        a5db255103fefe9df9746d4169391c72e073b4df # unreleased
+        GIT_TAG        d38fae88fda3a9264b05b7bd617ea20e09302e68 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        d6b3dc53f0e6bc277e96515dc85b3f95a80da9f0 # unreleased
+        GIT_TAG        a5db255103fefe9df9746d4169391c72e073b4df # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/middlewares/ble_middleware/GattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.cpp
@@ -66,15 +66,14 @@ namespace hal
         aci_gatt_read_char_value(connectionHandle, characteristic.CharacteristicValueHandle());
     }
 
-    void GattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)
+    void GattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone)
     {
-        this->onCharacteristicOperationsDone = [onDone](uint8_t result)
+        this->onCharacteristicOperationsDone = [this, onDone](uint8_t result)
         {
-            onDone(result == BLE_STATUS_SUCCESS ? services::OperationStatus::success : services::OperationStatus::error);
+            onDone(result);
         };
 
-        if (auto status = aci_gatt_write_char_value(connectionHandle, characteristic.CharacteristicValueHandle(), data.size(), data.cbegin()); status != BLE_STATUS_SUCCESS)
-            onDone(status == BLE_STATUS_INSUFFICIENT_RESOURCES ? services::OperationStatus::retry : services::OperationStatus::error);
+        aci_gatt_write_char_value(connectionHandle, characteristic.CharacteristicValueHandle(), data.size(), data.cbegin());
     }
 
     void GattClientSt::WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)

--- a/hal_st/middlewares/ble_middleware/GattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.cpp
@@ -68,13 +68,13 @@ namespace hal
 
     void GattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)
     {
-        this->onCharacteristicOperationsDone = [this, onDone](uint8_t result)
+        this->onCharacteristicOperationsDone = [onDone](uint8_t result)
         {
-            onDone(static_cast<services::OperationStatus>(result));
+            onDone(result == BLE_STATUS_SUCCESS ? services::OperationStatus::success : services::OperationStatus::error);
         };
 
         if (auto status = aci_gatt_write_char_value(connectionHandle, characteristic.CharacteristicValueHandle(), data.size(), data.cbegin()); status != BLE_STATUS_SUCCESS)
-            this->onCharacteristicOperationsDone(status == BLE_STATUS_INSUFFICIENT_RESOURCES ? static_cast<uint8_t>(services::OperationStatus::retry) : static_cast<uint8_t>(services::OperationStatus::error));
+            onDone(status == BLE_STATUS_INSUFFICIENT_RESOURCES ? services::OperationStatus::retry : services::OperationStatus::error);
     }
 
     void GattClientSt::WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)

--- a/hal_st/middlewares/ble_middleware/GattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.hpp
@@ -25,8 +25,8 @@ namespace hal
 
         // Implementation of services::GattClientCharacteristicOperations
         void Read(const services::GattClientObserver& characteristic, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(uint8_t)>& onDone) override;
-        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone) override;
-        void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data) override;
+        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
+        void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
         void EnableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void DisableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void EnableIndication(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;

--- a/hal_st/middlewares/ble_middleware/GattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.hpp
@@ -25,7 +25,7 @@ namespace hal
 
         // Implementation of services::GattClientCharacteristicOperations
         void Read(const services::GattClientObserver& characteristic, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(uint8_t)>& onDone) override;
-        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
+        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone) override;
         void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
         void EnableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void DisableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
@@ -33,7 +33,7 @@ namespace hal
         GattClientSt::Read(characteristic, onResponse, onDone);
     }
 
-    void TracingGattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)
+    void TracingGattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone)
     {
         tracer.Trace() << "TracingGattClientSt::Write, Value Handle: " << infra::hex << characteristic.CharacteristicValueHandle() << ", data: " << infra::AsHex(data);
         GattClientSt::Write(characteristic, data, onDone);

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
@@ -33,16 +33,16 @@ namespace hal
         GattClientSt::Read(characteristic, onResponse, onDone);
     }
 
-    void TracingGattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone)
+    void TracingGattClientSt::Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)
     {
         tracer.Trace() << "TracingGattClientSt::Write, Value Handle: " << infra::hex << characteristic.CharacteristicValueHandle() << ", data: " << infra::AsHex(data);
         GattClientSt::Write(characteristic, data, onDone);
     }
 
-    void TracingGattClientSt::WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data)
+    void TracingGattClientSt::WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone)
     {
         tracer.Trace() << "TracingGattClientSt::WriteWithoutResponse, Value Handle: " << infra::hex << characteristic.CharacteristicValueHandle() << ", data: " << infra::AsHex(data);
-        GattClientSt::WriteWithoutResponse(characteristic, data);
+        GattClientSt::WriteWithoutResponse(characteristic, data, onDone);
     }
 
     void TracingGattClientSt::EnableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone)

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
@@ -19,8 +19,8 @@ namespace hal
 
         // Implementation of services::GattClientCharacteristicOperations
         void Read(const services::GattClientObserver& characteristic, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(uint8_t)>& onDone) override;
-        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone) override;
-        void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data) override;
+        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
+        void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
         void EnableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void DisableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void EnableIndication(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
@@ -19,7 +19,7 @@ namespace hal
 
         // Implementation of services::GattClientCharacteristicOperations
         void Read(const services::GattClientObserver& characteristic, const infra::Function<void(const infra::ConstByteRange&)>& onResponse, const infra::Function<void(uint8_t)>& onDone) override;
-        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
+        void Write(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(uint8_t)>& onDone) override;
         void WriteWithoutResponse(const services::GattClientObserver& characteristic, infra::ConstByteRange data, const infra::Function<void(services::OperationStatus)>& onDone) override;
         void EnableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;
         void DisableNotification(const services::GattClientObserver& characteristic, const infra::Function<void(uint8_t)>& onDone) override;


### PR DESCRIPTION
Fix to retry when WriteWithoutResponse return an error due to insufficient resources in the stack.

# Dependency
https://github.com/philips-software/amp-embedded-infra-lib/pull/930
