### PR TITLE
feat: allow resetting the SysTick timer

### DIFF
--- a/hal_st/stm32fxxx/SystemTickTimerService.cpp
+++ b/hal_st/stm32fxxx/SystemTickTimerService.cpp
@@ -14,7 +14,12 @@ namespace hal
         : infra::TickOnInterruptTimerService(id, tickDuration)
     {
         Register(SysTick_IRQn);
-        SysTick->LOAD = SystemCoreClock / (1000000000 / std::chrono::duration_cast<std::chrono::nanoseconds>(tickDuration).count()) - 1ul;
+        Reset();
+    }
+
+    void SystemTickTimerService::Reset()
+    {
+        SysTick->LOAD = SystemCoreClock / (1000000000 / std::chrono::duration_cast<std::chrono::nanoseconds>(TickOnInterruptTimerService::Resolution()).count()) - 1UL;
         SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
         SysTick->VAL = 0;
     }

--- a/hal_st/stm32fxxx/SystemTickTimerService.hpp
+++ b/hal_st/stm32fxxx/SystemTickTimerService.hpp
@@ -18,6 +18,7 @@ namespace hal
     public:
         SystemTickTimerService(infra::Duration tickDuration = std::chrono::milliseconds(1), uint32_t id = infra::systemTimerServiceId);
 
+        void Reset();
         infra::TimePoint Now() const override;
 
     protected:


### PR DESCRIPTION
After clock reconfiguration it is necessary to reset the SysTick timer to take the current SystemCoreClock into account.