### PR TITLE
fix: the HSI48 oscillator is disabled by the random number generator

### DIFF
--- a/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
@@ -18,8 +18,7 @@ namespace hal
         HSEM->C1IER |= 1 << static_cast<uint32_t>(semaphore);
 
         while (!IsLockedByCurrentCore(semaphore))
-        {
-        }
+        {}
     }
 
     void SynchronousHardwareSemaphoreMasterStm::Release(hal::Semaphore semaphore) const
@@ -30,7 +29,7 @@ namespace hal
         HSEM->C1IER &= ~mask;
     }
 
-    volatile bool SynchronousHardwareSemaphoreMasterStm::IsLockedByCurrentCore(hal::Semaphore semaphore) const
+    bool SynchronousHardwareSemaphoreMasterStm::IsLockedByCurrentCore(hal::Semaphore semaphore) const
     {
         return (HSEM->RLR[static_cast<uint32_t>(semaphore)] == (HSEM_R_LOCK | HSEM_CR_COREID_CURRENT));
     }

--- a/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
@@ -17,8 +17,9 @@ namespace hal
     {
         HSEM->C1IER |= 1 << static_cast<uint32_t>(semaphore);
 
-        while (HSEM->RLR[static_cast<uint32_t>(semaphore)] != (HSEM_R_LOCK | HSEM_CR_COREID_CURRENT))
-        {}
+        while (!IsLockedByCurrentCore(semaphore))
+        {
+        }
     }
 
     void SynchronousHardwareSemaphoreMasterStm::Release(hal::Semaphore semaphore) const
@@ -27,6 +28,11 @@ namespace hal
         HSEM->C1ICR = mask;
         HSEM->R[static_cast<uint32_t>(semaphore)] = HSEM_CR_COREID_CURRENT;
         HSEM->C1IER &= ~mask;
+    }
+
+    volatile bool SynchronousHardwareSemaphoreMasterStm::IsLockedByCurrentCore(hal::Semaphore semaphore) const
+    {
+        return (HSEM->RLR[static_cast<uint32_t>(semaphore)] == (HSEM_R_LOCK | HSEM_CR_COREID_CURRENT));
     }
 
     SynchronousHardwareSemaphoreStm::SynchronousHardwareSemaphoreStm(SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMaster, Semaphore semaphore)

--- a/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.cpp
@@ -31,7 +31,7 @@ namespace hal
 
     bool SynchronousHardwareSemaphoreMasterStm::IsLockedByCurrentCore(hal::Semaphore semaphore) const
     {
-        return (HSEM->RLR[static_cast<uint32_t>(semaphore)] == (HSEM_R_LOCK | HSEM_CR_COREID_CURRENT));
+        return HSEM->RLR[static_cast<uint32_t>(semaphore)] == HSEM_R_LOCK | HSEM_CR_COREID_CURRENT;
     }
 
     SynchronousHardwareSemaphoreStm::SynchronousHardwareSemaphoreStm(SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMaster, Semaphore semaphore)

--- a/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.hpp
@@ -27,7 +27,7 @@ namespace hal
 
         void WaitLock(hal::Semaphore semaphore) const;
         void Release(hal::Semaphore semaphore) const;
-        volatile bool IsLockedByCurrentCore(hal::Semaphore semaphore) const;
+        bool IsLockedByCurrentCore(hal::Semaphore semaphore) const;
     };
 
     class SynchronousHardwareSemaphoreStm

--- a/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousHardwareSemaphoreStm.hpp
@@ -27,6 +27,7 @@ namespace hal
 
         void WaitLock(hal::Semaphore semaphore) const;
         void Release(hal::Semaphore semaphore) const;
+        volatile bool IsLockedByCurrentCore(hal::Semaphore semaphore) const;
     };
 
     class SynchronousHardwareSemaphoreStm

--- a/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.cpp
@@ -32,8 +32,7 @@ namespace hal
         {
             LL_RCC_HSI48_Enable();
             while (!LL_RCC_HSI48_IsReady())
-            {
-            }
+            {}
 
             disableHsi48OnFinalization = true;
         }

--- a/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.hpp
@@ -16,6 +16,16 @@ namespace hal
         void GenerateRandomData(infra::ByteRange result) override;
 
     private:
+        class ConditionalHsi48Enable
+        {
+        public:
+            ConditionalHsi48Enable(hal::SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMasterStm);
+            ~ConditionalHsi48Enable();
+
+        private:
+            bool allowEnable;
+        };
+
         infra::DelayedProxyCreator<hal::SynchronousRandomDataGenerator, void()> hwRngCreator;
         hal::SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMasterStm;
     };

--- a/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousSynchronizedRandomDataGeneratorStm.hpp
@@ -16,14 +16,14 @@ namespace hal
         void GenerateRandomData(infra::ByteRange result) override;
 
     private:
-        class ConditionalHsi48Enable
+        class Hsi48Enabler
         {
         public:
-            ConditionalHsi48Enable(hal::SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMasterStm);
-            ~ConditionalHsi48Enable();
+            Hsi48Enabler(hal::SynchronousHardwareSemaphoreMasterStm& synchronousHardwareSemaphoreMasterStm);
+            ~Hsi48Enabler();
 
         private:
-            bool allowEnable;
+            bool disableHsi48OnFinalization = false;
         };
 
         infra::DelayedProxyCreator<hal::SynchronousRandomDataGenerator, void()> hwRngCreator;


### PR DESCRIPTION
Fixes: #605 

On the WB55 the HSI48 oscillator is used by the RNG peripheral and USB. When currently using the RNG on CPU1, the HSI48 will be disabled, causing any active USB connection to drop as well. This PR modifies the RNG implementation to match the CPU2 behavior:

> The RNG peripheral access requires getting Sem0. In addition, the CPU2 makes one attempt to get Sem5. If this is successful, it switches ON the HSI48 oscillator and configures the 48 MHz clock selection of the RNG IP to be HSI48. This assumes the RCC is configured to feed the RNG IP with a 48 MHz clock and not either LSI or LSE. In the latter case, the previous step is done anyway even though not relevant and the RNG operates on the selected clock. When Sem5 is busy, the CPU2 does not change anything in the RNG clock configuration and uses the current configuration.