### PR TITLE
fix: MII clock range after link down

### DIFF
--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -133,7 +133,10 @@ namespace hal
                         GetObserver().LinkUp(speed);
                     }
                     else
+                    {
                         GetObserver().LinkDown();
+                        SetMiiClockRange();
+                    }
                 }
             });
     }


### PR DESCRIPTION
On link down, the MAC layer (typically) resets all ETH and MAC registers, including the MII clock range configuration. Fix this by configuring the clock range after calling link down.