### PR TITLE
feat: improve Pinout Table Generation

### DIFF
--- a/hal_st/stm32fxxx/CMakeLists.txt
+++ b/hal_st/stm32fxxx/CMakeLists.txt
@@ -195,7 +195,13 @@ if (TARGET_MCU_VENDOR STREQUAL st)
         message(FATAL_ERROR "Unknown TARGET_MCU \"${TARGET_MCU}\". Please configure HALST_XML_GPIO and HALST_XML_STM32.")
     endif()
 
-    generate_xslt(hal_st.stm32fxxx generated/stm32fxxx/PinoutTableDefaultStructure.xml GeneratePinoutTableStructure.xsl PinoutTableItems.xml
+    if (HALST_XML_PINOUT_TABLE_ITEMS)
+        set(pinout_table_items "${CMAKE_SOURCE_DIR}/${HALST_XML_PINOUT_TABLE_ITEMS}")
+    else()
+        set(pinout_table_items "${CMAKE_CURRENT_SOURCE_DIR}/PinoutTableItems.xml")
+    endif()
+
+    generate_xslt(hal_st.stm32fxxx generated/stm32fxxx/PinoutTableDefaultStructure.xml GeneratePinoutTableStructure.xsl ${pinout_table_items}
         --stringparam gpio-document ${gpio_xml} --stringparam mcu-document ${mcu_xml})
     generate_xslt(hal_st.stm32fxxx generated/stm32fxxx/PinoutTableDefault.cpp GeneratePinoutTableCpp.xsl "${CMAKE_CURRENT_BINARY_DIR}/generated/stm32fxxx/PinoutTableDefaultStructure.xml")
     generate_xslt(hal_st.stm32fxxx generated/stm32fxxx/PinoutTableDefault.hpp GeneratePinoutTableHpp.xsl "${CMAKE_CURRENT_BINARY_DIR}/generated/stm32fxxx/PinoutTableDefaultStructure.xml")

--- a/hal_st/stm32fxxx/GeneratePinoutTableCpp.xsl
+++ b/hal_st/stm32fxxx/GeneratePinoutTableCpp.xsl
@@ -39,7 +39,7 @@ namespace hal
 
 </xsl:text>
   </xsl:template>
-  
+
   <xsl:template match="pin" mode="list-pins">
     <xsl:if test="count(*) != 0">
       <xsl:text><![CDATA[    constexpr std::array<const GpioStm::PinPosition, ]]></xsl:text>
@@ -64,7 +64,7 @@ namespace hal
 </xsl:text>
     </xsl:if>
   </xsl:template>
-  
+
   <xsl:template match="gpio_pin">
     <xsl:if test="position() mod 4 = 1">
       <xsl:text>       </xsl:text>
@@ -92,8 +92,7 @@ namespace hal
       <xsl:text>        {
 </xsl:text>
       <xsl:text>            PinConfigTypeStm::</xsl:text>
-      <xsl:value-of select="concat(translate(substring(../@name, 1, 1), $uppercase, $lowercase), substring(../@name, 2))"/>
-      <xsl:value-of select="@name"/>
+      <xsl:value-of select="concat(translate(substring(@type, 1, 1), $uppercase, $lowercase), substring(@type, 2))"/>
       <xsl:text>,
 </xsl:text>
       <xsl:text>            pinoutTable</xsl:text>

--- a/hal_st/stm32fxxx/GeneratePinoutTableStructure.xsl
+++ b/hal_st/stm32fxxx/GeneratePinoutTableStructure.xsl
@@ -102,6 +102,17 @@
         </xsl:otherwise>
       </xsl:choose>
 
+      <xsl:attribute name="type">
+        <xsl:choose>
+          <xsl:when test="@type != ''">
+            <xsl:value-of select="@type"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="concat(../@name, @name)"/>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:attribute>
+
       <xsl:apply-templates/>
     </pin>
   </xsl:template>


### PR DESCRIPTION
This PR changes the Pinout Table Generation in the following ways:

- **Allow setting the PinConfigTypeStm type**: When provided, take the Pin's `type` attribute as value for PinConfigTypeStm, otherwise use the concatenation of Peripheral name and Pin name, as it was before this change.

- **Allow providing custom PinoutTableItems.xml**: The PinoutTableItems.xml defines hardware specific IO configuration for peripherals like Speed or WeakPull. This change allows providing a xml file customized for individual hardware.