### PR TITLE
chore: merge address and address type into a single GapAddress parameter in BLE middleware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        b8d43013c2dfb66322bb7c416c16391406601a49 # unreleased
+        GIT_TAG        997c85e30b4e712764f3853059181b6e1e09f43a # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        bcb58544b493ae12f1215b565acfb0bd73f2295c # unreleased
+        GIT_TAG        b8d43013c2dfb66322bb7c416c16391406601a49 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -94,9 +94,9 @@ namespace hal
         aci_gap_terminate(connectionContext.connectionHandle, remoteUserTerminatedConnection);
     }
 
-    void GapCentralSt::SetAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType)
+    void GapCentralSt::SetAddress(services::GapAddress address)
     {
-        GapSt::SetAddress(macAddress, addressType);
+        GapSt::SetAddress(address);
     }
 
     void GapCentralSt::StartDeviceDiscovery()

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -5,6 +5,7 @@
 #include "hal_st/middlewares/ble_middleware/GapSt.hpp"
 #include "infra/timer/Timer.hpp"
 #include "infra/util/AutoResetFunction.hpp"
+#include "services/ble/Gap.hpp"
 
 namespace hal
 {
@@ -19,7 +20,7 @@ namespace hal
         void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;
         void CancelConnect() override;
         void Disconnect() override;
-        void SetAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType) override;
+        void SetAddress(services::GapAddress address) override;
         void StartDeviceDiscovery() override;
         void StopDeviceDiscovery() override;
         std::optional<hal::MacAddress> ResolvePrivateAddress(hal::MacAddress address) const override;

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -36,8 +36,16 @@ namespace hal
         services::GapAddress address;
         uint8_t length = 0;
 
-        aci_hal_read_config_data(CONFIG_DATA_PUBADDR_OFFSET, &length, address.address.data());
-        address.type = services::GapDeviceAddressType::publicAddress;
+        if (identityAddressType == GAP_PUBLIC_ADDR)
+        {
+            aci_hal_read_config_data(CONFIG_DATA_PUBADDR_OFFSET, &length, address.address.data());
+            address.type = services::GapDeviceAddressType::publicAddress;
+        }
+        else
+        {
+            aci_hal_read_config_data(CONFIG_DATA_RANDOM_ADDRESS_OFFSET, &length, address.address.data());
+            address.type = services::GapDeviceAddressType::randomAddress;
+        }
 
         return address;
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -43,7 +43,7 @@ namespace hal
 
         struct Configuration
         {
-            const MacAddress& address;
+            const services::GapAddress& address;
             const GapService& gapService;
             const RootKeys& rootKeys;
             const Security& security;
@@ -98,7 +98,7 @@ namespace hal
         [[nodiscard]] virtual SecureConnection SecurityLevelToSecureConnection(services::GapPairing::SecurityLevel level) const;
         [[nodiscard]] virtual uint8_t SecurityLevelToMITM(services::GapPairing::SecurityLevel level) const;
 
-        void SetAddress(const MacAddress& address, services::GapDeviceAddressType addressType) const;
+        void SetAddress(services::GapAddress address) const;
 
     private:
         // Implementation of HciEventSink
@@ -120,6 +120,7 @@ namespace hal
         };
 
         ConnectionContext connectionContext;
+        uint8_t identityAddressType;
         uint8_t ownAddressType;
         services::GapPairing::SecurityLevel securityLevel;
 

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -24,13 +24,13 @@ namespace hal
         GapCentralSt::Disconnect();
     }
 
-    void TracingGapCentralSt::SetAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType)
+    void TracingGapCentralSt::SetAddress(services::GapAddress address)
     {
         tracer.Trace() << "TracingGapCentralSt::SetAddress, MAC address: "
-                       << infra::AsMacAddress(macAddress)
+                       << infra::AsMacAddress(address.address)
                        << ", type: "
-                       << addressType;
-        GapCentralSt::SetAddress(macAddress, addressType);
+                       << address.type;
+        GapCentralSt::SetAddress(address);
     }
 
     void TracingGapCentralSt::StartDeviceDiscovery()

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
@@ -15,7 +15,7 @@ namespace hal
         // Implementation of services::GapCentral
         void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;
         void Disconnect() override;
-        void SetAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType) override;
+        void SetAddress(services::GapAddress address) override;
         void StartDeviceDiscovery() override;
         void StopDeviceDiscovery() override;
         std::optional<hal::MacAddress> ResolvePrivateAddress(hal::MacAddress address) const override;


### PR DESCRIPTION
merge address and address type into a single GapAddress parameter in BLE middleware