### PR TITLE
ci: change EMIL update to run once per week

### DIFF
--- a/.github/workflows/update-emil-git-tag.yml
+++ b/.github/workflows/update-emil-git-tag.yml
@@ -3,7 +3,7 @@ name: Update amp-embedded-infra-lib Git Tag
 
 on:
   schedule:
-    - cron: "0 6 * * *"
+    - cron: "0 6 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Currently it runs every day, which seems excessive. It creates a lot of clutter in the notifications, commit history, etc. Now it will run every Monday at 6 AM.