### PR TITLE
feat: Handle multicast MAC addresses with pass-all-multicast filter

### DIFF
--- a/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
@@ -1,6 +1,7 @@
 #include "hal_st/stm32fxxx/EthernetMacStm.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/BitLogic.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include DEVICE_HEADER
 
 namespace hal
@@ -86,6 +87,15 @@ namespace hal
 
     void EthernetMacStm::AddMacAddressFilter(MacAddress address)
     {
+        // Multicast MAC addresses (first byte LSB set) use the pass-all-multicast filter
+        // to avoid exhausting the 3 exact-match slots (MACA1-3) with group addresses.
+        if ((address[0] & 1) != 0)
+        {
+            if (multicastFilterCount++ == 0)
+                peripheralEthernet[0]->MACPFR |= ETH_MACPFR_PM;
+            return;
+        }
+
         uint32_t lr = reinterpret_cast<const uint32_t*>(address.data())[0];
         uint32_t hr = (reinterpret_cast<const uint32_t*>(address.data())[1] & 0xffff) | (1 << 31);
 
@@ -106,13 +116,21 @@ namespace hal
         }
         else
         {
-            // No free mac address found. Hint: implement address hashing
+            // No free unicast exact-match slot found
             abort();
         }
     }
 
     void EthernetMacStm::RemoveMacAddressFilter(MacAddress address)
     {
+        if ((address[0] & 1) != 0)
+        {
+            really_assert(multicastFilterCount > 0);
+            if (--multicastFilterCount == 0)
+                peripheralEthernet[0]->MACPFR &= ~ETH_MACPFR_PM;
+            return;
+        }
+
         uint32_t lr = reinterpret_cast<const uint32_t*>(address.data())[0];
         uint32_t hr = (reinterpret_cast<const uint32_t*>(address.data())[1] & 0xffff) | (1 << 31);
 
@@ -133,7 +151,7 @@ namespace hal
         }
         else
         {
-            // Address not found
+            // Unicast address not found
             abort();
         }
     }

--- a/hal_st/stm32fxxx/EthernetMacStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacStm.cpp
@@ -1,6 +1,7 @@
 #include "hal_st/stm32fxxx/EthernetMacStm.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/BitLogic.hpp"
+#include "infra/util/ReallyAssert.hpp"
 
 #if defined(HAS_PERIPHERAL_ETHERNET)
 
@@ -45,6 +46,15 @@ namespace hal
 
     void EthernetMacStm::AddMacAddressFilter(MacAddress address)
     {
+        // Multicast MAC addresses (first byte LSB set) use the pass-all-multicast filter
+        // to avoid exhausting the 3 exact-match slots (MACA1-3) with group addresses.
+        if ((address[0] & 1) != 0)
+        {
+            if (multicastFilterCount++ == 0)
+                peripheralEthernet[0]->MACFFR |= ETH_MACFFR_PAM;
+            return;
+        }
+
         uint32_t lr = reinterpret_cast<const uint32_t*>(address.data())[0];
         uint32_t hr = (reinterpret_cast<const uint32_t*>(address.data())[1] & 0xffff) | (1 << 31);
 
@@ -65,13 +75,21 @@ namespace hal
         }
         else
         {
-            // No free mac address found. Hint: implement address hashing
+            // No free unicast exact-match slot found
             abort();
         }
     }
 
     void EthernetMacStm::RemoveMacAddressFilter(MacAddress address)
     {
+        if ((address[0] & 1) != 0)
+        {
+            really_assert(multicastFilterCount > 0);
+            if (--multicastFilterCount == 0)
+                peripheralEthernet[0]->MACFFR &= ~ETH_MACFFR_PAM;
+            return;
+        }
+
         uint32_t lr = reinterpret_cast<const uint32_t*>(address.data())[0];
         uint32_t hr = (reinterpret_cast<const uint32_t*>(address.data())[1] & 0xffff) | (1 << 31);
 
@@ -92,7 +110,7 @@ namespace hal
         }
         else
         {
-            // Address not found
+            // Unicast address not found
             abort();
         }
     }

--- a/hal_st/stm32fxxx/EthernetMacStm.hpp
+++ b/hal_st/stm32fxxx/EthernetMacStm.hpp
@@ -79,6 +79,8 @@ namespace hal
 
         ReceiveDescriptors receiveDescriptors;
         SendDescriptors sendDescriptors;
+
+        uint8_t multicastFilterCount = 0;
     };
 }
 


### PR DESCRIPTION
`AddMacAddressFilter` and `RemoveMacAddressFilter` previously treated all MAC addresses as unicast, assigning them to the 3 hardware exact-match slots (MACA1–MACA3). When multicast group addresses were added, these slots were quickly exhausted, causing an abort.

This change detects multicast addresses (LSB of the first octet set) and instead enables the hardware pass-all-multicast filter (`ETH_MACFFR_PAM` on F4/F7, `ETH_MACPFR_PM` on H5xx). A reference count tracks the number of active multicast filters so the pass-all-multicast bit is only enabled while at least one multicast address is registered.

### Changes

- **EthernetMacStm.hpp**: Added `multicastFilterCount` member to track active multicast filter registrations.
- **EthernetMacStm.cpp** (F4/F7): Multicast addresses toggle `ETH_MACFFR_PAM` on `MACFFR`; unicast addresses continue to use exact-match slots.
- **EthernetMacH5xxStm.cpp** (H5xx): Same logic using `ETH_MACPFR_PM` on `MACPFR`.
- `RemoveMacAddressFilter` uses `really_assert` to guard against underflow of the multicast reference count.