### PR TITLE
fix: ensure DMA stream is stopped on destruction

### DIFF
--- a/hal_st/stm32fxxx/DmaStm.cpp
+++ b/hal_st/stm32fxxx/DmaStm.cpp
@@ -488,6 +488,7 @@ namespace hal
 
     DmaStm::Stream::~Stream()
     {
+        StopTransfer();
         if (streamIndex != 0xff)
             dma.ReleaseStream(dmaIndex, streamIndex);
     }


### PR DESCRIPTION
It might happen that on re-construction of the same Stream, the transfer complete interrupt might be emitted immediately after enabling without valid callback available. This results in abort().
Fix this by stopping ongoing DMA transfers on Stream destruction.