### PR TITLE
feat: highcyclearea interface change

### DIFF
--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -3,7 +3,6 @@
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/ByteRange.hpp"
 #include "infra/util/MemoryRange.hpp"
-#include "stm32h563xx.h"
 #include <cstdint>
 #include DEVICE_HEADER
 

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -47,31 +47,10 @@ namespace
 
 namespace hal
 {
-    FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(uint32_t bank)
-        : flashMemory(GetBankRange(bank))
-        , bank(bank)
+    FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
+        : flashMemory(flashMemory)
+        , bank(GetBankRange(reinterpret_cast<uint32_t>(flashMemory.begin())) == bank1Range ? FLASH_BANK_1 : FLASH_BANK_2)
     {
-        FLASH_OBProgramInitTypeDef obCurrent{};
-        obCurrent.Banks = bank;
-        HAL_FLASHEx_OBGetConfig(&obCurrent);
-
-        bool updateNeeded = obCurrent.EDATASize != bankSectorNumber;
-        if (updateNeeded)
-        {
-            HAL_FLASH_OB_Unlock();
-
-            FLASH_OBProgramInitTypeDef obInit;
-            obInit.Banks = bank;
-            obInit.OptionType = OPTIONBYTE_EDATA;
-            obInit.EDATASize = bankSectorNumber;
-
-            auto result = HAL_FLASHEx_OBProgram(&obInit);
-            really_assert(result == HAL_OK);
-
-            HAL_FLASH_OB_Launch();
-
-            HAL_FLASH_OB_Lock();
-        }
     }
 
     void FlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
@@ -137,8 +116,8 @@ namespace hal
         return sectorIndex * sectorSize;
     }
 
-    FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(uint32_t bank)
-        : FlashInternalHighCycleAreaStm(bank)
+    FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(HalfWordRange flashMemory)
+        : FlashInternalHighCycleAreaStm(flashMemory)
         , HighCycleAreaOrOtpIrqHandler()
     {}
 }

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -8,35 +8,9 @@
 
 namespace
 {
-    using ConstHalfWordRange = hal::FlashInternalHighCycleAreaStm::ConstHalfWordRange;
-
     constexpr uint32_t fullSize{ FLASH_EDATA_SIZE };
-    constexpr uint32_t bankSize{ fullSize / 2 };
-    constexpr uint32_t bankSectorNumber{ FLASH_EDATA_SECTOR_NB };
-    constexpr uint32_t sectorSize{ bankSize / bankSectorNumber };
-    constexpr uint32_t bankSectorOffset{ FLASH_SECTOR_NB - bankSectorNumber };
-
-    template<uint32_t address>
-    constexpr auto ptr()
-    {
-        return reinterpret_cast<const uint16_t*>(address);
-    }
-
-    const ConstHalfWordRange bank1Range{ ptr<FLASH_EDATA_BASE>(), ptr<FLASH_EDATA_BASE + bankSize>() };
-    const ConstHalfWordRange bank2Range{ ptr<FLASH_EDATA_BASE + bankSize>(), ptr<FLASH_EDATA_BASE + fullSize>() };
-
-    ConstHalfWordRange GetBankRange(uint32_t bank)
-    {
-        switch (bank)
-        {
-            case FLASH_BANK_1:
-                return bank1Range;
-            case FLASH_BANK_2:
-                return bank2Range;
-            default:
-                std::abort();
-        }
-    }
+    constexpr uint32_t fullbankSize{ fullSize / 2 };
+    constexpr uint32_t sectorSize{ fullbankSize / FLASH_EDATA_SECTOR_NB };
 
     void Copy(const uint16_t* begin, const uint16_t* end, uint16_t* destination)
     {
@@ -49,13 +23,19 @@ namespace hal
 {
     FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
         : flashMemory(flashMemory)
-        , bank(GetBankRange(reinterpret_cast<uint32_t>(flashMemory.begin())) == bank1Range ? FLASH_BANK_1 : FLASH_BANK_2)
+        , bankConfig(ReadBankConfig())
     {
+        const uint32_t totalEnabledSectors = bankConfig.enabledSectorsActiveBank + bankConfig.enabledSectorsInactiveBank;
+        const uint32_t totalEnabledHalfWords = totalEnabledSectors * sectorSize / sizeof(uint16_t);
+
+        really_assert(static_cast<uint32_t>(flashMemory.end() - flashMemory.begin()) == totalEnabledHalfWords);
     }
 
     void FlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
+        really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
+
         // address is byte-based, addressAdjusted is half-word-based
         auto addressAdjusted = address / 2;
         auto destination = infra::ReinterpretCastMemoryRange<uint16_t>(buffer);
@@ -67,6 +47,9 @@ namespace hal
 
     void FlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
     {
+        really_assert(buffer.size() % sizeof(uint16_t) == 0);
+        really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
+
         HAL_FLASH_Unlock();
 
         detail::AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_HALFWORD_EDATA, true>(buffer, address, reinterpret_cast<uint32_t>(flashMemory.begin()));
@@ -82,14 +65,33 @@ namespace hal
 
         uint32_t sectorError = 0;
 
-        FLASH_EraseInitTypeDef eraseInitStruct{};
-        eraseInitStruct.Banks = bank;
-        eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
-        eraseInitStruct.Sector = beginIndex + bankSectorOffset;
-        eraseInitStruct.NbSectors = endIndex - beginIndex;
+        const uint32_t activeSectorsEnd = std::min(endIndex, bankConfig.enabledSectorsActiveBank);
+        if (beginIndex < activeSectorsEnd)
+        {
+            FLASH_EraseInitTypeDef eraseInitStruct{};
+            eraseInitStruct.Banks = bankConfig.activeBank;
+            eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
+            eraseInitStruct.Sector = beginIndex + FLASH_SECTOR_NB - bankConfig.enabledSectorsActiveBank;
+            eraseInitStruct.NbSectors = activeSectorsEnd - beginIndex;
 
-        auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &sectorError);
-        really_assert(result == HAL_OK);
+            auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &sectorError);
+            really_assert(result == HAL_OK);
+            really_assert(sectorError == 0xFFFFFFFFU);
+        }
+
+        const uint32_t inactiveSectorsBegin = std::max(beginIndex, bankConfig.enabledSectorsActiveBank);
+        if (inactiveSectorsBegin < endIndex)
+        {
+            FLASH_EraseInitTypeDef eraseInitStruct{};
+            eraseInitStruct.Banks = bankConfig.inactiveBank;
+            eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
+            eraseInitStruct.Sector = (inactiveSectorsBegin - bankConfig.enabledSectorsActiveBank) + FLASH_SECTOR_NB - bankConfig.enabledSectorsInactiveBank;
+            eraseInitStruct.NbSectors = endIndex - inactiveSectorsBegin;
+
+            auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &sectorError);
+            really_assert(result == HAL_OK);
+            really_assert(sectorError == 0xFFFFFFFFU);
+        }
 
         HAL_FLASH_Lock();
 
@@ -98,7 +100,7 @@ namespace hal
 
     uint32_t FlashInternalHighCycleAreaStm::NumberOfSectors() const
     {
-        return bankSectorNumber;
+        return bankConfig.enabledSectorsActiveBank + bankConfig.enabledSectorsInactiveBank;
     }
 
     uint32_t FlashInternalHighCycleAreaStm::SizeOfSector(uint32_t sectorIndex) const
@@ -114,6 +116,24 @@ namespace hal
     uint32_t FlashInternalHighCycleAreaStm::AddressOfSector(uint32_t sectorIndex) const
     {
         return sectorIndex * sectorSize;
+    }
+
+    FlashInternalHighCycleAreaStm::BankConfig FlashInternalHighCycleAreaStm::ReadBankConfig()
+    {
+        const bool swapBankEnabled = (FLASH->OPTSR_CUR & FLASH_OPTSR_SWAP_BANK) != 0;
+        const uint32_t activeBank = swapBankEnabled ? FLASH_BANK_2 : FLASH_BANK_1;
+        const uint32_t inactiveBank = swapBankEnabled ? FLASH_BANK_1 : FLASH_BANK_2;
+
+        FLASH_OBProgramInitTypeDef obCurrent{};
+        obCurrent.Banks = activeBank;
+        HAL_FLASHEx_OBGetConfig(&obCurrent);
+        const uint32_t enabledSectorsActiveBank = obCurrent.EDATASize;
+
+        obCurrent.Banks = inactiveBank;
+        HAL_FLASHEx_OBGetConfig(&obCurrent);
+        const uint32_t enabledSectorsInactiveBank = obCurrent.EDATASize;
+
+        return { activeBank, inactiveBank, enabledSectorsActiveBank, enabledSectorsInactiveBank };
     }
 
     FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(HalfWordRange flashMemory)

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -3,6 +3,7 @@
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/ByteRange.hpp"
 #include "infra/util/MemoryRange.hpp"
+#include "stm32h563xx.h"
 #include <cstdint>
 #include DEVICE_HEADER
 
@@ -25,6 +26,9 @@ namespace hal
         : flashMemory(flashMemory)
         , bankConfig(ReadBankConfig())
     {
+        really_assert(reinterpret_cast<uintptr_t>(flashMemory.begin()) >= FLASH_EDATA_BASE_NS);
+        really_assert(reinterpret_cast<uintptr_t>(flashMemory.end()) <= FLASH_EDATA_BASE_NS + FLASH_EDATA_SIZE);
+
         const uint32_t totalEnabledSectors = bankConfig.enabledSectorsActiveBank + bankConfig.enabledSectorsInactiveBank;
         const uint32_t totalEnabledHalfWords = totalEnabledSectors * sectorSize / sizeof(uint16_t);
 

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -51,7 +51,7 @@ namespace hal
     void FlashInternalHighCycleAreaWorker::ReadBuffer(infra::ByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
-        really_assert(address + buffer.size() <= TotalSectors() * sectorSize);
+        really_assert(address + buffer.size() <= TotalSectors() * SectorSize());
 
         // address is byte-based, addressAdjusted is half-word-based
         auto addressAdjusted = address / 2;
@@ -63,7 +63,7 @@ namespace hal
     void FlashInternalHighCycleAreaWorker::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
-        really_assert(address + buffer.size() <= TotalSectors() * sectorSize);
+        really_assert(address + buffer.size() <= TotalSectors() * SectorSize());
 
         HAL_FLASH_Unlock();
 
@@ -115,6 +115,11 @@ namespace hal
     uint32_t FlashInternalHighCycleAreaWorker::TotalSectors() const
     {
         return amountOfSectorsInActiveBankInMemoryRange + amountOfSectorsInInactiveBankInMemoryRange;
+    }
+
+    uint32_t FlashInternalHighCycleAreaWorker::SectorSize()
+    {
+        return sectorSize;
     }
 
     FlashInternalHighCycleAreaWorker::BankConfig FlashInternalHighCycleAreaWorker::ReadBankConfig()

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -3,6 +3,7 @@
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/ByteRange.hpp"
 #include "infra/util/MemoryRange.hpp"
+#include "infra/util/ReallyAssert.hpp"
 #include <cstdint>
 #include DEVICE_HEADER
 
@@ -11,6 +12,7 @@ namespace
     constexpr uint32_t fullSize{ FLASH_EDATA_SIZE };
     constexpr uint32_t fullbankSize{ fullSize / 2 };
     constexpr uint32_t sectorSize{ fullbankSize / FLASH_EDATA_SECTOR_NB };
+    const uint32_t activeBankEndAddress{ FLASH_EDATA_BASE_NS + fullbankSize };
 
     void Copy(const uint16_t* begin, const uint16_t* end, uint16_t* destination)
     {
@@ -21,20 +23,32 @@ namespace
 
 namespace hal
 {
-    FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
+    FlashInternalHighCycleAreaWorker::FlashInternalHighCycleAreaWorker(HalfWordRange flashMemory)
         : flashMemory(flashMemory)
         , bankConfig(ReadBankConfig())
     {
-        really_assert(reinterpret_cast<uintptr_t>(flashMemory.begin()) >= FLASH_EDATA_BASE_NS);
-        really_assert(reinterpret_cast<uintptr_t>(flashMemory.end()) <= FLASH_EDATA_BASE_NS + FLASH_EDATA_SIZE);
+        const uint32_t flashBeginAddress = reinterpret_cast<uintptr_t>(flashMemory.begin());
+        const uint32_t flashEndAddress = reinterpret_cast<uintptr_t>(flashMemory.end());
 
-        const uint32_t totalEnabledSectors = bankConfig.enabledSectorsActiveBank + bankConfig.enabledSectorsInactiveBank;
-        const uint32_t totalEnabledHalfWords = totalEnabledSectors * sectorSize / sizeof(uint16_t);
+        // The flashMemory range must be fully contained within the flash edata area (high cycle area)
+        really_assert(flashBeginAddress >= FLASH_EDATA_BASE_NS);
+        really_assert(flashEndAddress <= FLASH_EDATA_BASE_NS + FLASH_EDATA_SIZE);
 
-        really_assert(static_cast<uint32_t>(flashMemory.end() - flashMemory.begin()) == totalEnabledHalfWords);
+        amountOfSectorsInActiveBankInMemoryRange_ = static_cast<uint32_t>(std::ceil(static_cast<float>(std::min(activeBankEndAddress, flashEndAddress) - flashBeginAddress) / sectorSize));
+        amountOfSectorsInInactiveBankInMemoryRange_ = static_cast<uint32_t>(std::ceil(static_cast<float>(flashEndAddress - std::max(activeBankEndAddress, flashBeginAddress)) / sectorSize));
+
+        really_assert(bankConfig.enabledSectorsActiveBank >= amountOfSectorsInActiveBankInMemoryRange_);
+        really_assert(bankConfig.enabledSectorsInactiveBank >= amountOfSectorsInInactiveBankInMemoryRange_);
+
+        if (amountOfSectorsInInactiveBankInMemoryRange_ > 0 && amountOfSectorsInInactiveBankInMemoryRange_ < 8)
+        {
+            // If some but not all sectors of the inactive bank are part of the memory map then the active bank must not contain any mapped sectors
+            // otherwise the memory mapped high cycle area would be not continuous
+            really_assert(amountOfSectorsInActiveBankInMemoryRange_ == 0);
+        }
     }
 
-    void FlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    void FlashInternalHighCycleAreaWorker::ReadBuffer(infra::ByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
         really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
@@ -44,11 +58,9 @@ namespace hal
         auto destination = infra::ReinterpretCastMemoryRange<uint16_t>(buffer);
         // explicitely copy data uint16_t aligned and prevent gcc from (falsely) optimizing to memmove which will reinterpret as arrays of uint8_t
         Copy(flashMemory.begin() + addressAdjusted, flashMemory.begin() + addressAdjusted + destination.size(), destination.begin());
-
-        infra::EventDispatcher::Instance().Schedule(onDone);
     }
 
-    void FlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    void FlashInternalHighCycleAreaWorker::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
         really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
@@ -58,70 +70,69 @@ namespace hal
         detail::AlignedWriteBuffer<uint16_t, FLASH_TYPEPROGRAM_HALFWORD_EDATA, true>(buffer, address, reinterpret_cast<uint32_t>(flashMemory.begin()));
 
         HAL_FLASH_Lock();
-
-        infra::EventDispatcher::Instance().Schedule(onDone);
     }
 
-    void FlashInternalHighCycleAreaStm::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
+    void FlashInternalHighCycleAreaWorker::EraseSectors(uint32_t beginIndex, uint32_t endIndex)
     {
         HAL_FLASH_Unlock();
 
-        uint32_t sectorError = 0;
+        really_assert(beginIndex < NumberOfSectors());
+        really_assert(endIndex <= NumberOfSectors());
 
-        const uint32_t activeSectorsEnd = std::min(endIndex, bankConfig.enabledSectorsActiveBank);
+        const uint32_t activeSectorsEnd = std::min(endIndex, amountOfSectorsInActiveBankInMemoryRange_);
         if (beginIndex < activeSectorsEnd)
         {
             FLASH_EraseInitTypeDef eraseInitStruct{};
             eraseInitStruct.Banks = bankConfig.activeBank;
             eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
-            eraseInitStruct.Sector = beginIndex + FLASH_SECTOR_NB - bankConfig.enabledSectorsActiveBank;
+            eraseInitStruct.Sector = beginIndex + FLASH_SECTOR_NB - amountOfSectorsInActiveBankInMemoryRange_;
             eraseInitStruct.NbSectors = activeSectorsEnd - beginIndex;
 
+            uint32_t sectorError = 0;
             auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &sectorError);
             really_assert(result == HAL_OK);
             really_assert(sectorError == 0xFFFFFFFFU);
         }
 
-        const uint32_t inactiveSectorsBegin = std::max(beginIndex, bankConfig.enabledSectorsActiveBank);
+        const uint32_t inactiveSectorsBegin = std::max(beginIndex, amountOfSectorsInActiveBankInMemoryRange_);
         if (inactiveSectorsBegin < endIndex)
         {
             FLASH_EraseInitTypeDef eraseInitStruct{};
             eraseInitStruct.Banks = bankConfig.inactiveBank;
             eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
-            eraseInitStruct.Sector = (inactiveSectorsBegin - bankConfig.enabledSectorsActiveBank) + FLASH_SECTOR_NB - bankConfig.enabledSectorsInactiveBank;
+            eraseInitStruct.Sector = (inactiveSectorsBegin - amountOfSectorsInActiveBankInMemoryRange_) + FLASH_SECTOR_NB - amountOfSectorsInInactiveBankInMemoryRange_;
             eraseInitStruct.NbSectors = endIndex - inactiveSectorsBegin;
 
+            uint32_t sectorError = 0;
             auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &sectorError);
             really_assert(result == HAL_OK);
             really_assert(sectorError == 0xFFFFFFFFU);
         }
 
         HAL_FLASH_Lock();
-
-        infra::EventDispatcher::Instance().Schedule(onDone);
     }
 
-    uint32_t FlashInternalHighCycleAreaStm::NumberOfSectors() const
+    uint32_t FlashInternalHighCycleAreaWorker::NumberOfSectors() const
     {
-        return bankConfig.enabledSectorsActiveBank + bankConfig.enabledSectorsInactiveBank;
+        return amountOfSectorsInActiveBankInMemoryRange_ + amountOfSectorsInInactiveBankInMemoryRange_;
     }
 
-    uint32_t FlashInternalHighCycleAreaStm::SizeOfSector(uint32_t sectorIndex) const
+    uint32_t FlashInternalHighCycleAreaWorker::SizeOfSector([[maybe_unused]] uint32_t sectorIndex) const
     {
         return sectorSize;
     }
 
-    uint32_t FlashInternalHighCycleAreaStm::SectorOfAddress(uint32_t address) const
+    uint32_t FlashInternalHighCycleAreaWorker::SectorOfAddress(uint32_t address) const
     {
         return address / sectorSize;
     }
 
-    uint32_t FlashInternalHighCycleAreaStm::AddressOfSector(uint32_t sectorIndex) const
+    uint32_t FlashInternalHighCycleAreaWorker::AddressOfSector(uint32_t sectorIndex) const
     {
         return sectorIndex * sectorSize;
     }
 
-    FlashInternalHighCycleAreaStm::BankConfig FlashInternalHighCycleAreaStm::ReadBankConfig()
+    FlashInternalHighCycleAreaWorker::BankConfig FlashInternalHighCycleAreaWorker::ReadBankConfig()
     {
         const bool swapBankEnabled = (FLASH->OPTSR_CUR & FLASH_OPTSR_SWAP_BANK) != 0;
         const uint32_t activeBank = swapBankEnabled ? FLASH_BANK_2 : FLASH_BANK_1;
@@ -139,8 +150,30 @@ namespace hal
         return { activeBank, inactiveBank, enabledSectorsActiveBank, enabledSectorsInactiveBank };
     }
 
+    void FlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    {
+        FlashInternalHighCycleAreaWorker::WriteBuffer(buffer, address);
+        infra::EventDispatcher::Instance().Schedule(onDone);
+    }
+
+    void FlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone)
+    {
+        FlashInternalHighCycleAreaWorker::ReadBuffer(buffer, address);
+        infra::EventDispatcher::Instance().Schedule(onDone);
+    }
+
+    void FlashInternalHighCycleAreaStm::EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone)
+    {
+        FlashInternalHighCycleAreaWorker::EraseSectors(beginIndex, endIndex);
+        infra::EventDispatcher::Instance().Schedule(onDone);
+    }
+
+    FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
+        : FlashInternalHighCycleAreaWorker(flashMemory)
+        , FlashHomogeneous{ FlashInternalHighCycleAreaWorker::NumberOfSectors(), FlashInternalHighCycleAreaWorker::SizeOfSector(0) }
+    {}
+
     FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(HalfWordRange flashMemory)
         : FlashInternalHighCycleAreaStm(flashMemory)
-        , HighCycleAreaOrOtpIrqHandler()
     {}
 }

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -34,17 +34,17 @@ namespace hal
         really_assert(flashBeginAddress >= FLASH_EDATA_BASE_NS);
         really_assert(flashEndAddress <= FLASH_EDATA_BASE_NS + FLASH_EDATA_SIZE);
 
-        amountOfSectorsInActiveBankInMemoryRange_ = static_cast<uint32_t>(std::ceil(static_cast<float>(std::min(activeBankEndAddress, flashEndAddress) - flashBeginAddress) / sectorSize));
-        amountOfSectorsInInactiveBankInMemoryRange_ = static_cast<uint32_t>(std::ceil(static_cast<float>(flashEndAddress - std::max(activeBankEndAddress, flashBeginAddress)) / sectorSize));
+        amountOfSectorsInActiveBankInMemoryRange = static_cast<uint32_t>(std::ceil(static_cast<float>(std::min(activeBankEndAddress, flashEndAddress) - flashBeginAddress) / sectorSize));
+        amountOfSectorsInInactiveBankInMemoryRange = static_cast<uint32_t>(std::ceil(static_cast<float>(flashEndAddress - std::max(activeBankEndAddress, flashBeginAddress)) / sectorSize));
 
-        really_assert(bankConfig.enabledSectorsActiveBank >= amountOfSectorsInActiveBankInMemoryRange_);
-        really_assert(bankConfig.enabledSectorsInactiveBank >= amountOfSectorsInInactiveBankInMemoryRange_);
+        really_assert(bankConfig.enabledSectorsActiveBank >= amountOfSectorsInActiveBankInMemoryRange);
+        really_assert(bankConfig.enabledSectorsInactiveBank >= amountOfSectorsInInactiveBankInMemoryRange);
 
-        if (amountOfSectorsInInactiveBankInMemoryRange_ > 0 && amountOfSectorsInInactiveBankInMemoryRange_ < 8)
+        if (amountOfSectorsInInactiveBankInMemoryRange > 0 && amountOfSectorsInInactiveBankInMemoryRange < 8)
         {
             // If some but not all sectors of the inactive bank are part of the memory map then the active bank must not contain any mapped sectors
             // otherwise the memory mapped high cycle area would be not continuous
-            really_assert(amountOfSectorsInActiveBankInMemoryRange_ == 0);
+            really_assert(amountOfSectorsInActiveBankInMemoryRange == 0);
         }
     }
 
@@ -79,13 +79,13 @@ namespace hal
         really_assert(beginIndex < NumberOfSectors());
         really_assert(endIndex <= NumberOfSectors());
 
-        const uint32_t activeSectorsEnd = std::min(endIndex, amountOfSectorsInActiveBankInMemoryRange_);
+        const uint32_t activeSectorsEnd = std::min(endIndex, amountOfSectorsInActiveBankInMemoryRange);
         if (beginIndex < activeSectorsEnd)
         {
             FLASH_EraseInitTypeDef eraseInitStruct{};
             eraseInitStruct.Banks = bankConfig.activeBank;
             eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
-            eraseInitStruct.Sector = beginIndex + FLASH_SECTOR_NB - amountOfSectorsInActiveBankInMemoryRange_;
+            eraseInitStruct.Sector = beginIndex + FLASH_SECTOR_NB - amountOfSectorsInActiveBankInMemoryRange;
             eraseInitStruct.NbSectors = activeSectorsEnd - beginIndex;
 
             uint32_t sectorError = 0;
@@ -94,13 +94,13 @@ namespace hal
             really_assert(sectorError == 0xFFFFFFFFU);
         }
 
-        const uint32_t inactiveSectorsBegin = std::max(beginIndex, amountOfSectorsInActiveBankInMemoryRange_);
+        const uint32_t inactiveSectorsBegin = std::max(beginIndex, amountOfSectorsInActiveBankInMemoryRange);
         if (inactiveSectorsBegin < endIndex)
         {
             FLASH_EraseInitTypeDef eraseInitStruct{};
             eraseInitStruct.Banks = bankConfig.inactiveBank;
             eraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
-            eraseInitStruct.Sector = (inactiveSectorsBegin - amountOfSectorsInActiveBankInMemoryRange_) + FLASH_SECTOR_NB - amountOfSectorsInInactiveBankInMemoryRange_;
+            eraseInitStruct.Sector = (inactiveSectorsBegin - amountOfSectorsInActiveBankInMemoryRange) + FLASH_SECTOR_NB - amountOfSectorsInInactiveBankInMemoryRange;
             eraseInitStruct.NbSectors = endIndex - inactiveSectorsBegin;
 
             uint32_t sectorError = 0;
@@ -114,7 +114,7 @@ namespace hal
 
     uint32_t FlashInternalHighCycleAreaWorker::NumberOfSectors() const
     {
-        return amountOfSectorsInActiveBankInMemoryRange_ + amountOfSectorsInInactiveBankInMemoryRange_;
+        return amountOfSectorsInActiveBankInMemoryRange + amountOfSectorsInInactiveBankInMemoryRange;
     }
 
     uint32_t FlashInternalHighCycleAreaWorker::SizeOfSector([[maybe_unused]] uint32_t sectorIndex) const

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -1,4 +1,5 @@
 #include "hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp"
+#include "hal/synchronous_interfaces/SynchronousFlashHomogeneous.hpp"
 #include "hal_st/stm32fxxx/FlashInternalStmDetail.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/ByteRange.hpp"
@@ -51,7 +52,7 @@ namespace hal
     void FlashInternalHighCycleAreaWorker::ReadBuffer(infra::ByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
-        really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
+        really_assert(address + buffer.size() <= TotalSectors() * sectorSize);
 
         // address is byte-based, addressAdjusted is half-word-based
         auto addressAdjusted = address / 2;
@@ -63,7 +64,7 @@ namespace hal
     void FlashInternalHighCycleAreaWorker::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
     {
         really_assert(buffer.size() % sizeof(uint16_t) == 0);
-        really_assert(address + buffer.size() <= NumberOfSectors() * sectorSize);
+        really_assert(address + buffer.size() <= TotalSectors() * sectorSize);
 
         HAL_FLASH_Unlock();
 
@@ -76,8 +77,8 @@ namespace hal
     {
         HAL_FLASH_Unlock();
 
-        really_assert(beginIndex < NumberOfSectors());
-        really_assert(endIndex <= NumberOfSectors());
+        really_assert(beginIndex < TotalSectors());
+        really_assert(endIndex <= TotalSectors());
 
         const uint32_t activeSectorsEnd = std::min(endIndex, amountOfSectorsInActiveBankInMemoryRange);
         if (beginIndex < activeSectorsEnd)
@@ -112,24 +113,9 @@ namespace hal
         HAL_FLASH_Lock();
     }
 
-    uint32_t FlashInternalHighCycleAreaWorker::NumberOfSectors() const
+    uint32_t FlashInternalHighCycleAreaWorker::TotalSectors() const
     {
         return amountOfSectorsInActiveBankInMemoryRange + amountOfSectorsInInactiveBankInMemoryRange;
-    }
-
-    uint32_t FlashInternalHighCycleAreaWorker::SizeOfSector([[maybe_unused]] uint32_t sectorIndex) const
-    {
-        return sectorSize;
-    }
-
-    uint32_t FlashInternalHighCycleAreaWorker::SectorOfAddress(uint32_t address) const
-    {
-        return address / sectorSize;
-    }
-
-    uint32_t FlashInternalHighCycleAreaWorker::AddressOfSector(uint32_t sectorIndex) const
-    {
-        return sectorIndex * sectorSize;
     }
 
     FlashInternalHighCycleAreaWorker::BankConfig FlashInternalHighCycleAreaWorker::ReadBankConfig()
@@ -170,10 +156,30 @@ namespace hal
 
     FlashInternalHighCycleAreaStm::FlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
         : FlashInternalHighCycleAreaWorker(flashMemory)
-        , FlashHomogeneous{ FlashInternalHighCycleAreaWorker::NumberOfSectors(), FlashInternalHighCycleAreaWorker::SizeOfSector(0) }
+        , FlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), sectorSize }
     {}
 
     FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(HalfWordRange flashMemory)
         : FlashInternalHighCycleAreaStm(flashMemory)
     {}
+
+    SynchronousFlashInternalHighCycleAreaStm::SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
+        : FlashInternalHighCycleAreaWorker(flashMemory)
+        , SynchronousFlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), sectorSize }
+    {}
+
+    void SynchronousFlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
+    {
+        FlashInternalHighCycleAreaWorker::WriteBuffer(buffer, address);
+    }
+
+    void SynchronousFlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address)
+    {
+        FlashInternalHighCycleAreaWorker::ReadBuffer(buffer, address);
+    }
+
+    void SynchronousFlashInternalHighCycleAreaStm::EraseSectors(uint32_t beginIndex, uint32_t endIndex)
+    {
+        FlashInternalHighCycleAreaWorker::EraseSectors(beginIndex, endIndex);
+    }
 }

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.cpp
@@ -1,5 +1,4 @@
 #include "hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp"
-#include "hal/synchronous_interfaces/SynchronousFlashHomogeneous.hpp"
 #include "hal_st/stm32fxxx/FlashInternalStmDetail.hpp"
 #include "infra/event/EventDispatcher.hpp"
 #include "infra/util/ByteRange.hpp"
@@ -162,24 +161,4 @@ namespace hal
     FlashInternalHighCycleAreaStm::WithIrqHandler::WithIrqHandler(HalfWordRange flashMemory)
         : FlashInternalHighCycleAreaStm(flashMemory)
     {}
-
-    SynchronousFlashInternalHighCycleAreaStm::SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
-        : FlashInternalHighCycleAreaWorker(flashMemory)
-        , SynchronousFlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), sectorSize }
-    {}
-
-    void SynchronousFlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
-    {
-        FlashInternalHighCycleAreaWorker::WriteBuffer(buffer, address);
-    }
-
-    void SynchronousFlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address)
-    {
-        FlashInternalHighCycleAreaWorker::ReadBuffer(buffer, address);
-    }
-
-    void SynchronousFlashInternalHighCycleAreaStm::EraseSectors(uint32_t beginIndex, uint32_t endIndex)
-    {
-        FlashInternalHighCycleAreaWorker::EraseSectors(beginIndex, endIndex);
-    }
 }

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -14,7 +14,6 @@ namespace hal
     {
     public:
         using HalfWordRange = infra::MemoryRange<uint16_t>;
-        using ConstHalfWordRange = infra::MemoryRange<const uint16_t>;
 
         class WithIrqHandler;
 
@@ -30,8 +29,19 @@ namespace hal
         uint32_t AddressOfSector(uint32_t sectorIndex) const override;
 
     private:
+        struct BankConfig
+        {
+            uint32_t activeBank;
+            uint32_t inactiveBank;
+            uint32_t enabledSectorsActiveBank;
+            uint32_t enabledSectorsInactiveBank;
+        };
+
+        static BankConfig ReadBankConfig();
+
+    private:
         HalfWordRange flashMemory;
-        uint32_t bank;
+        const BankConfig bankConfig;
     };
 
     class FlashInternalHighCycleAreaStm::WithIrqHandler

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -18,7 +18,7 @@ namespace hal
 
         class WithIrqHandler;
 
-        explicit FlashInternalHighCycleAreaStm(uint32_t bank = FLASH_BANK_2);
+        explicit FlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
 
         void WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
         void ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
@@ -30,7 +30,7 @@ namespace hal
         uint32_t AddressOfSector(uint32_t sectorIndex) const override;
 
     private:
-        ConstHalfWordRange flashMemory;
+        HalfWordRange flashMemory;
         uint32_t bank;
     };
 
@@ -39,7 +39,7 @@ namespace hal
         , private HighCycleAreaOrOtpIrqHandler
     {
     public:
-        explicit WithIrqHandler(uint32_t bank = FLASH_BANK_2);
+        explicit WithIrqHandler(HalfWordRange flashMemory);
     };
 }
 

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -38,14 +38,13 @@ namespace hal
             uint32_t enabledSectorsInactiveBank;
         };
 
-        uint32_t amountOfSectorsInActiveBankInMemoryRange_;
-        uint32_t amountOfSectorsInInactiveBankInMemoryRange_;
-
         static BankConfig ReadBankConfig();
 
     private:
         HalfWordRange flashMemory;
         const BankConfig bankConfig;
+        uint32_t amountOfSectorsInActiveBankInMemoryRange;
+        uint32_t amountOfSectorsInInactiveBankInMemoryRange;
     };
 
     class FlashInternalHighCycleAreaStm

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -25,6 +25,7 @@ namespace hal
         void EraseSectors(uint32_t beginIndex, uint32_t endIndexExcluding);
 
         uint32_t TotalSectors() const;
+        static uint32_t SectorSize();
 
     private:
         struct BankConfig

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -2,6 +2,7 @@
 #define HAL_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
 
 #include "hal/interfaces/FlashHomogeneous.hpp"
+#include "hal/synchronous_interfaces/SynchronousFlashHomogeneous.hpp"
 #include "hal_st/stm32fxxx/HighCycleAreaOrOtpIrqHandler.hpp"
 #include "infra/util/MemoryRange.hpp"
 #include <cstdint>
@@ -24,10 +25,7 @@ namespace hal
         void ReadBuffer(infra::ByteRange buffer, uint32_t address);
         void EraseSectors(uint32_t beginIndex, uint32_t endIndexExcluding);
 
-        uint32_t NumberOfSectors() const;
-        uint32_t SizeOfSector(uint32_t sectorIndex) const;
-        uint32_t SectorOfAddress(uint32_t address) const;
-        uint32_t AddressOfSector(uint32_t sectorIndex) const;
+        uint32_t TotalSectors() const;
 
     private:
         struct BankConfig
@@ -70,6 +68,21 @@ namespace hal
     {
     public:
         explicit WithIrqHandler(HalfWordRange flashMemory);
+    };
+
+    class SynchronousFlashInternalHighCycleAreaStm
+        : private FlashInternalHighCycleAreaWorker
+        , public SynchronousFlashHomogeneous
+    {
+    public:
+        using HalfWordRange = FlashInternalHighCycleAreaWorker::HalfWordRange;
+
+        explicit SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
+
+        // implementation of Flash interface
+        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address) override;
+        void ReadBuffer(infra::ByteRange buffer, uint32_t address) override;
+        void EraseSectors(uint32_t beginIndex, uint32_t endIndex) override;
     };
 }
 

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -1,7 +1,7 @@
 #ifndef HAL_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
 #define HAL_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
 
-#include "hal/interfaces/Flash.hpp"
+#include "hal/interfaces/FlashHomogeneous.hpp"
 #include "hal_st/stm32fxxx/HighCycleAreaOrOtpIrqHandler.hpp"
 #include "infra/util/MemoryRange.hpp"
 #include <cstdint>
@@ -9,24 +9,25 @@
 
 namespace hal
 {
-    class FlashInternalHighCycleAreaStm
-        : public Flash
+    // This class is used to implement both the synchronous and asynchronous version of the high cycle flash,
+    // as the underlying implementation is the same except for scheduling the onDone callback.
+    class FlashInternalHighCycleAreaWorker
     {
     public:
         using HalfWordRange = infra::MemoryRange<uint16_t>;
 
         class WithIrqHandler;
 
-        explicit FlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
+        explicit FlashInternalHighCycleAreaWorker(HalfWordRange flashMemory);
 
-        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
-        void ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
-        void EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone) override;
+        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address);
+        void ReadBuffer(infra::ByteRange buffer, uint32_t address);
+        void EraseSectors(uint32_t beginIndex, uint32_t endIndexExcluding);
 
-        uint32_t NumberOfSectors() const override;
-        uint32_t SizeOfSector(uint32_t sectorIndex) const override;
-        uint32_t SectorOfAddress(uint32_t address) const override;
-        uint32_t AddressOfSector(uint32_t sectorIndex) const override;
+        uint32_t NumberOfSectors() const;
+        uint32_t SizeOfSector(uint32_t sectorIndex) const;
+        uint32_t SectorOfAddress(uint32_t address) const;
+        uint32_t AddressOfSector(uint32_t sectorIndex) const;
 
     private:
         struct BankConfig
@@ -37,11 +38,31 @@ namespace hal
             uint32_t enabledSectorsInactiveBank;
         };
 
+        uint32_t amountOfSectorsInActiveBankInMemoryRange_;
+        uint32_t amountOfSectorsInInactiveBankInMemoryRange_;
+
         static BankConfig ReadBankConfig();
 
     private:
         HalfWordRange flashMemory;
         const BankConfig bankConfig;
+    };
+
+    class FlashInternalHighCycleAreaStm
+        : private FlashInternalHighCycleAreaWorker
+        , public FlashHomogeneous
+    {
+    public:
+        using HalfWordRange = FlashInternalHighCycleAreaWorker::HalfWordRange;
+
+        class WithIrqHandler;
+
+        explicit FlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
+
+        // implementation of Flash interface
+        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
+        void ReadBuffer(infra::ByteRange buffer, uint32_t address, infra::Function<void()> onDone) override;
+        void EraseSectors(uint32_t beginIndex, uint32_t endIndex, infra::Function<void()> onDone) override;
     };
 
     class FlashInternalHighCycleAreaStm::WithIrqHandler

--- a/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp
@@ -2,7 +2,6 @@
 #define HAL_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
 
 #include "hal/interfaces/FlashHomogeneous.hpp"
-#include "hal/synchronous_interfaces/SynchronousFlashHomogeneous.hpp"
 #include "hal_st/stm32fxxx/HighCycleAreaOrOtpIrqHandler.hpp"
 #include "infra/util/MemoryRange.hpp"
 #include <cstdint>
@@ -68,21 +67,6 @@ namespace hal
     {
     public:
         explicit WithIrqHandler(HalfWordRange flashMemory);
-    };
-
-    class SynchronousFlashInternalHighCycleAreaStm
-        : private FlashInternalHighCycleAreaWorker
-        , public SynchronousFlashHomogeneous
-    {
-    public:
-        using HalfWordRange = FlashInternalHighCycleAreaWorker::HalfWordRange;
-
-        explicit SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
-
-        // implementation of Flash interface
-        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address) override;
-        void ReadBuffer(infra::ByteRange buffer, uint32_t address) override;
-        void EraseSectors(uint32_t beginIndex, uint32_t endIndex) override;
     };
 }
 

--- a/hal_st/synchronous_stm32fxxx/CMakeLists.txt
+++ b/hal_st/synchronous_stm32fxxx/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(hal_st.synchronous_stm32fxxx PRIVATE
     $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32wbxx>:SynchronousHardwareSemaphoreStm.hpp>
     $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:SynchronousOneTimeProgrammableFlashStm.cpp>
     $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:SynchronousOneTimeProgrammableFlashStm.hpp>
+    $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:SynchronousFlashInternalHighCycleAreaStm.cpp>
+    $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:SynchronousFlashInternalHighCycleAreaStm.hpp>
     SynchronousRandomDataGeneratorStm.cpp
     SynchronousRandomDataGeneratorStm.hpp
     SynchronousSpiMasterStm.cpp

--- a/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.cpp
@@ -2,18 +2,11 @@
 #include <cstdint>
 #include DEVICE_HEADER
 
-namespace
-{
-    constexpr uint32_t fullSize{ FLASH_EDATA_SIZE };
-    constexpr uint32_t fullbankSize{ fullSize / 2 };
-    constexpr uint32_t sectorSize{ fullbankSize / FLASH_EDATA_SECTOR_NB };
-}
-
 namespace hal
 {
     SynchronousFlashInternalHighCycleAreaStm::SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
         : FlashInternalHighCycleAreaWorker(flashMemory)
-        , SynchronousFlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), sectorSize }
+        , SynchronousFlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), FlashInternalHighCycleAreaWorker::SectorSize() }
     {}
 
     void SynchronousFlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)

--- a/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.cpp
@@ -1,0 +1,33 @@
+#include "hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.hpp"
+#include <cstdint>
+#include DEVICE_HEADER
+
+namespace
+{
+    constexpr uint32_t fullSize{ FLASH_EDATA_SIZE };
+    constexpr uint32_t fullbankSize{ fullSize / 2 };
+    constexpr uint32_t sectorSize{ fullbankSize / FLASH_EDATA_SECTOR_NB };
+}
+
+namespace hal
+{
+    SynchronousFlashInternalHighCycleAreaStm::SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory)
+        : FlashInternalHighCycleAreaWorker(flashMemory)
+        , SynchronousFlashHomogeneous{ FlashInternalHighCycleAreaWorker::TotalSectors(), sectorSize }
+    {}
+
+    void SynchronousFlashInternalHighCycleAreaStm::WriteBuffer(infra::ConstByteRange buffer, uint32_t address)
+    {
+        FlashInternalHighCycleAreaWorker::WriteBuffer(buffer, address);
+    }
+
+    void SynchronousFlashInternalHighCycleAreaStm::ReadBuffer(infra::ByteRange buffer, uint32_t address)
+    {
+        FlashInternalHighCycleAreaWorker::ReadBuffer(buffer, address);
+    }
+
+    void SynchronousFlashInternalHighCycleAreaStm::EraseSectors(uint32_t beginIndex, uint32_t endIndex)
+    {
+        FlashInternalHighCycleAreaWorker::EraseSectors(beginIndex, endIndex);
+    }
+}

--- a/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousFlashInternalHighCycleAreaStm.hpp
@@ -1,0 +1,35 @@
+#ifndef HAL_SYNCHRONOUS_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
+#define HAL_SYNCHRONOUS_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP
+
+#include "hal/synchronous_interfaces/SynchronousFlashHomogeneous.hpp"
+#include "hal_st/stm32fxxx/FlashInternalHighCycleAreaStm.hpp"
+#include "hal_st/stm32fxxx/HighCycleAreaOrOtpIrqHandler.hpp"
+#include <cstdint>
+#include DEVICE_HEADER
+
+namespace hal
+{
+    class SynchronousFlashInternalHighCycleAreaStm
+        : private FlashInternalHighCycleAreaWorker
+        , public SynchronousFlashHomogeneous
+    {
+    public:
+        class WithIrqHandler;
+
+        using HalfWordRange = FlashInternalHighCycleAreaWorker::HalfWordRange;
+
+        explicit SynchronousFlashInternalHighCycleAreaStm(HalfWordRange flashMemory);
+
+        // implementation of Flash interface
+        void WriteBuffer(infra::ConstByteRange buffer, uint32_t address) override;
+        void ReadBuffer(infra::ByteRange buffer, uint32_t address) override;
+        void EraseSectors(uint32_t beginIndex, uint32_t endIndex) override;
+    };
+
+    class SynchronousFlashInternalHighCycleAreaStm::WithIrqHandler
+        : public SynchronousFlashInternalHighCycleAreaStm
+        , private HighCycleAreaOrOtpIrqHandler
+    {};
+}
+
+#endif // HAL_SYNCHRONOUS_FLASH_INTERNAL_HIGH_CYCLE_AREA_STM_HPP


### PR DESCRIPTION
* Change flash highcyclearea interface to support a memory range.
* Add support for a memory range over both flash banks with different highcyclearea sizes.
* Add support for a memory range that does not use all configured highcyclearea sectors.