### PR TITLE
feat: add SmiBusStm and decouple PHY management from EthernetMacStm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        90e3100817b7a075811426be8da0d85649d6f944 # unreleased
+        GIT_TAG        5b8d62c0a7103e961d588abb62ebec92f657a311 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/stm32fxxx/CMakeLists.txt
+++ b/hal_st/stm32fxxx/CMakeLists.txt
@@ -60,6 +60,8 @@ target_sources(hal_st.stm32fxxx PRIVATE
     EthernetMacStm.hpp
     EthernetSmiStm.cpp
     EthernetSmiStm.hpp
+    SmiBusStm.cpp
+    SmiBusStm.hpp
     $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:FlashInternalHighCycleAreaStm.cpp>
     $<$<STREQUAL:${TARGET_MCU_FAMILY},stm32h5xx>:FlashInternalHighCycleAreaStm.hpp>
     FlashInternalStm.cpp

--- a/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
@@ -6,9 +6,8 @@
 
 namespace hal
 {
-    EthernetMacStm::EthernetMacStm(EthernetSmi& ethernetSmi, LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
-        : ethernetSmi(ethernetSmi)
-        , macAddress(macAddress)
+    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
+        : macAddress(macAddress)
         , interrupt(peripheralEthernetIrq[0], [this]()
               {
                   Interrupt();

--- a/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
@@ -6,7 +6,7 @@
 
 namespace hal
 {
-    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
+    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, MacAddress macAddress)
         : macAddress(macAddress)
         , interrupt(peripheralEthernetIrq[0], [this]()
               {

--- a/hal_st/stm32fxxx/EthernetMacStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacStm.cpp
@@ -7,9 +7,8 @@
 
 namespace hal
 {
-    EthernetMacStm::EthernetMacStm(EthernetSmi& ethernetSmi, LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
-        : ethernetSmi(ethernetSmi)
-        , macAddress(macAddress)
+    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
+        : macAddress(macAddress)
         , interrupt(peripheralEthernetIrq[0], [this]()
               {
                   Interrupt();
@@ -119,7 +118,8 @@ namespace hal
     {
         peripheralEthernet[0]->DMABMR |= ETH_DMABMR_SR;
         while ((peripheralEthernet[0]->DMABMR & ETH_DMABMR_SR) != 0)
-        {}
+        {
+        }
     }
 
     void EthernetMacStm::Interrupt()

--- a/hal_st/stm32fxxx/EthernetMacStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacStm.cpp
@@ -7,7 +7,7 @@
 
 namespace hal
 {
-    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, std::array<uint8_t, 6> macAddress)
+    EthernetMacStm::EthernetMacStm(LinkSpeed linkSpeed, MacAddress macAddress)
         : macAddress(macAddress)
         , interrupt(peripheralEthernetIrq[0], [this]()
               {

--- a/hal_st/stm32fxxx/EthernetMacStm.hpp
+++ b/hal_st/stm32fxxx/EthernetMacStm.hpp
@@ -15,7 +15,7 @@ namespace hal
         : public EthernetMac
     {
     public:
-        EthernetMacStm(EthernetSmi& ethernetSmi, LinkSpeed linkSpeed, MacAddress macAddress);
+        EthernetMacStm(LinkSpeed linkSpeed, MacAddress macAddress);
         ~EthernetMacStm();
 
         void SendBuffer(infra::ConstByteRange data, bool last) override;
@@ -73,7 +73,6 @@ namespace hal
         };
 
     private:
-        EthernetSmi& ethernetSmi;
         MacAddress macAddress;
         DispatchedInterruptHandler interrupt;
 

--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -17,8 +17,6 @@ namespace hal
         RunPhy();
     }
 
-    EthernetSmiStm::~EthernetSmiStm() = default;
-
     uint16_t EthernetSmiStm::PhyAddress() const
     {
         return phyAddress;

--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -9,9 +9,10 @@ namespace hal
 {
     EthernetSmiStm::EthernetSmiStm(hal::GpioPinStm& ethernetMdio, hal::GpioPinStm& ethernetMdc, hal::GpioPinStm& ethernetRmiiRefClk,
         hal::GpioPinStm& ethernetRmiiCrsDv, hal::GpioPinStm& ethernetRmiiRxD0, hal::GpioPinStm& ethernetRmiiRxD1,
-        hal::GpioPinStm& ethernetRmiiTxEn, hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint16_t phyAddress)
+        hal::GpioPinStm& ethernetRmiiTxEn, hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint8_t phyAddress)
         : smiBus(ethernetMdio, ethernetMdc, ethernetRmiiRefClk, ethernetRmiiCrsDv, ethernetRmiiRxD0, ethernetRmiiRxD1, ethernetRmiiTxEn, ethernetRmiiTxD0, ethernetRmiiTxD1)
         , phyAddress(phyAddress)
+        , phy_(smiBus, phyAddress)
     {
         RunPhy();
     }
@@ -42,24 +43,21 @@ namespace hal
     {
         sequencer.Execute([this]()
             {
-                WritePhyRegister(phyBasicControlRegister, infra::Bit<uint16_t>(phyBcrReset));
+                phy_.WriteBcr(infra::Bit<uint16_t>(services::SmiPhy::BasicControlRegister::ResetBit));
             });
         sequencer.DoWhile();
         Delay(std::chrono::milliseconds(1));
         sequencer.Execute([this]()
             {
-                phyControlRegisterValue = ReadPhyRegister(phyBasicControlRegister);
+                savedBcr_ = phy_.ReadBcr();
             });
         sequencer.EndDoWhile([this]()
             {
-                return infra::IsBitSet(phyControlRegisterValue, phyBcrReset);
+                return services::SmiPhy::BasicControlRegister::IsResetting(savedBcr_);
             });
         sequencer.Execute([this]()
             {
-                uint16_t status = ReadPhyRegister(phyBasicStatusRegister);
-                autoNegotiation = infra::IsBitSet(status, phyBsrAutoNegotiationAbility);
-                if (autoNegotiation)
-                    WritePhyRegister(phyBasicControlRegister, infra::Bit<uint16_t>(phyBcrAutoNegotiationEnable));
+                phy_.EnableAutoNegIfCapable();
             });
     }
 
@@ -67,63 +65,15 @@ namespace hal
     {
         sequencer.Execute([this]()
             {
-                uint16_t status = ReadPhyRegister(phyBasicStatusRegister);
-                bool autoNegotiationComplete = autoNegotiation ? infra::IsBitSet(status, phyBsrAutoNegotiationComplete) : true;
-                bool newLinkUp = infra::IsBitSet(status, phyBsrLinkUp) && autoNegotiationComplete;
-
-                if (newLinkUp != linkUp)
+                const auto linkState = phy_.ReadLinkState();
+                if (linkState == services::SmiPhy::LinkState::Up)
+                    GetObserver().LinkUp(phy_.LinkSpeed());
+                else if (linkState == services::SmiPhy::LinkState::Down)
                 {
-                    linkUp = newLinkUp;
-
-                    if (linkUp)
-                    {
-                        LinkSpeed speed = autoNegotiation ? GetLinkSpeedNegotiated() : GetLinkSpeedLocal();
-                        GetObserver().LinkUp(speed);
-                    }
-                    else
-                    {
-                        GetObserver().LinkDown();
-                        smiBus.SetMiiClockRange();
-                    }
+                    GetObserver().LinkDown();
+                    smiBus.SetMiiClockRange();
                 }
             });
-    }
-
-    LinkSpeed EthernetSmiStm::GetLinkSpeedNegotiated() const
-    {
-        uint16_t linkAbility = ReadPhyRegister(phyAutoNegotiationAdvertisement);
-        uint16_t linkPartnerAbility = ReadPhyRegister(phyAutoNegotiationLinkPartnerAbility);
-        if (infra::IsBitSet(linkPartnerAbility, phyAnlpaFullDuplex100MHz) && infra::IsBitSet(linkAbility, phyAnlpaFullDuplex100MHz))
-            return LinkSpeed::fullDuplex100MHz;
-        else if (infra::IsBitSet(linkPartnerAbility, phyAnlpaHalfDuplex100MHz) && infra::IsBitSet(linkAbility, phyAnlpaHalfDuplex100MHz))
-            return LinkSpeed::halfDuplex100MHz;
-        else if (infra::IsBitSet(linkPartnerAbility, phyAnlpaFullDuplex10MHz) && infra::IsBitSet(linkAbility, phyAnlpaFullDuplex10MHz))
-            return LinkSpeed::fullDuplex10MHz;
-        else
-            return LinkSpeed::halfDuplex10MHz;
-    }
-
-    LinkSpeed EthernetSmiStm::GetLinkSpeedLocal() const
-    {
-        bool duplexMode = infra::IsBitSet(phyControlRegisterValue, phyBcrDuplexMode);
-        if (infra::IsBitSet(phyControlRegisterValue, phyBcrSpeedSelectLsb) && duplexMode)
-            return LinkSpeed::fullDuplex100MHz;
-        else if (infra::IsBitSet(phyControlRegisterValue, phyBcrSpeedSelectLsb) && !duplexMode)
-            return LinkSpeed::halfDuplex100MHz;
-        else if (!infra::IsBitSet(phyControlRegisterValue, phyBcrSpeedSelectLsb) && duplexMode)
-            return LinkSpeed::fullDuplex10MHz;
-        else
-            return LinkSpeed::halfDuplex10MHz;
-    }
-
-    uint16_t EthernetSmiStm::ReadPhyRegister(uint16_t reg) const
-    {
-        return smiBus.Read(static_cast<uint8_t>(phyAddress), reg);
-    }
-
-    void EthernetSmiStm::WritePhyRegister(uint16_t reg, uint16_t value)
-    {
-        smiBus.Write(static_cast<uint8_t>(phyAddress), reg, value);
     }
 
     void EthernetSmiStm::Delay(infra::Duration duration)

--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -10,36 +10,13 @@ namespace hal
     EthernetSmiStm::EthernetSmiStm(hal::GpioPinStm& ethernetMdio, hal::GpioPinStm& ethernetMdc, hal::GpioPinStm& ethernetRmiiRefClk,
         hal::GpioPinStm& ethernetRmiiCrsDv, hal::GpioPinStm& ethernetRmiiRxD0, hal::GpioPinStm& ethernetRmiiRxD1,
         hal::GpioPinStm& ethernetRmiiTxEn, hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint16_t phyAddress)
-        : ethernetMdio(ethernetMdio, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetMdc(ethernetMdc, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiRefClk(ethernetRmiiRefClk, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiCrsDv(ethernetRmiiCrsDv, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiRxD0(ethernetRmiiRxD0, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiRxD1(ethernetRmiiRxD1, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiTxEn(ethernetRmiiTxEn, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiTxD0(ethernetRmiiTxD0, hal::PinConfigTypeStm::ethernet, 0)
-        , ethernetRmiiTxD1(ethernetRmiiTxD1, hal::PinConfigTypeStm::ethernet, 0)
+        : smiBus(ethernetMdio, ethernetMdc, ethernetRmiiRefClk, ethernetRmiiCrsDv, ethernetRmiiRxD0, ethernetRmiiRxD1, ethernetRmiiTxEn, ethernetRmiiTxD0, ethernetRmiiTxD1)
         , phyAddress(phyAddress)
     {
-#if !defined(STM32H5)
-        __HAL_RCC_SYSCFG_CLK_ENABLE();
-        SYSCFG->PMC |= SYSCFG_PMC_MII_RMII_SEL; // Select RMII Mode
-#else
-        __HAL_RCC_SBS_CLK_ENABLE();
-        SBS->PMCR |= SBS_ETH_RMII; // Select RMII Mode
-        (void)SBS->PMCR;           // Dummy read to sync with ETH
-#endif
-
-        EnableClockEthernet(0);
-
-        SetMiiClockRange();
         RunPhy();
     }
 
-    EthernetSmiStm::~EthernetSmiStm()
-    {
-        DisableClockEthernet(0);
-    }
+    EthernetSmiStm::~EthernetSmiStm() = default;
 
     uint16_t EthernetSmiStm::PhyAddress() const
     {
@@ -59,39 +36,6 @@ namespace hal
                 Delay(std::chrono::milliseconds(200));
                 sequencer.EndWhile();
             });
-    }
-
-    void EthernetSmiStm::SetMiiClockRange()
-    {
-        uint32_t hclk = HAL_RCC_GetHCLKFreq();
-
-#if defined(STM32H5)
-        if (hclk >= 20000000 && hclk < 35000000)
-            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV16;
-        else if (hclk >= 35000000 && hclk < 60000000)
-            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV26;
-        else if (hclk >= 60000000 && hclk < 100000000)
-            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV42;
-        else if (hclk >= 100000000 && hclk < 150000000)
-            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV62;
-        else if (hclk >= 150000000 && hclk <= 250000000)
-            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV102;
-        else
-            std::abort();
-#else
-        if (hclk >= 20000000 && hclk < 35000000)
-            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div16;
-        else if (hclk >= 35000000 && hclk < 60000000)
-            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div26;
-        else if (hclk >= 60000000 && hclk < 100000000)
-            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div42;
-        else if (hclk >= 100000000 && hclk < 150000000)
-            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div62;
-        else if (hclk >= 150000000 && hclk <= 216000000)
-            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div102;
-        else
-            std::abort();
-#endif
     }
 
     void EthernetSmiStm::ResetPhy()
@@ -139,7 +83,7 @@ namespace hal
                     else
                     {
                         GetObserver().LinkDown();
-                        SetMiiClockRange();
+                        smiBus.SetMiiClockRange();
                     }
                 }
             });
@@ -174,42 +118,12 @@ namespace hal
 
     uint16_t EthernetSmiStm::ReadPhyRegister(uint16_t reg) const
     {
-#if defined(STM32H5)
-        peripheralEthernet[0]->MACMDIOAR = (peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_CR) | ((static_cast<uint32_t>(phyAddress) << 21) & ETH_MACMDIOAR_PA) | ((static_cast<uint32_t>(reg) << 16) & ETH_MACMDIOAR_RDA) | ETH_MACMDIOAR_MOC_RD | ETH_MACMDIOAR_MB;
-
-        while ((peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_MB) != 0)
-        {
-        }
-
-        return static_cast<uint16_t>(peripheralEthernet[0]->MACMDIODR);
-#else
-        peripheralEthernet[0]->MACMIIAR = (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_CR) | ((static_cast<uint32_t>(phyAddress) << 11) & ETH_MACMIIAR_PA) | ((static_cast<uint32_t>(reg) << 6) & ETH_MACMIIAR_MR) | ETH_MACMIIAR_MB;
-
-        while (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_MB != 0)
-        {
-        }
-
-        return peripheralEthernet[0]->MACMIIDR;
-#endif
+        return smiBus.Read(static_cast<uint8_t>(phyAddress), reg);
     }
 
     void EthernetSmiStm::WritePhyRegister(uint16_t reg, uint16_t value)
     {
-#if defined(STM32H5)
-        peripheralEthernet[0]->MACMDIODR = value;
-        peripheralEthernet[0]->MACMDIOAR = (peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_CR) | ((static_cast<uint32_t>(phyAddress) << 21) & ETH_MACMDIOAR_PA) | ((static_cast<uint32_t>(reg) << 16) & ETH_MACMDIOAR_RDA) | ETH_MACMDIOAR_MOC_WR | ETH_MACMDIOAR_MB;
-
-        while ((peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_MB) != 0)
-        {
-        }
-#else
-        peripheralEthernet[0]->MACMIIDR = value;
-        peripheralEthernet[0]->MACMIIAR = (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_CR) | ((static_cast<uint32_t>(phyAddress) << 11) & ETH_MACMIIAR_PA) | ((static_cast<uint32_t>(reg) << 6) & ETH_MACMIIAR_MR) | ETH_MACMIIAR_MW | ETH_MACMIIAR_MB;
-
-        while (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_MB != 0)
-        {
-        }
-#endif
+        smiBus.Write(static_cast<uint8_t>(phyAddress), reg, value);
     }
 
     void EthernetSmiStm::Delay(infra::Duration duration)

--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -64,6 +64,10 @@ namespace hal
         sequencer.Execute([this]()
             {
                 const auto linkState = phy_.ReadLinkState();
+                if (linkState == lastLinkState_)
+                    return;
+
+                lastLinkState_ = linkState;
                 if (linkState == services::SmiPhy::LinkState::Up)
                     GetObserver().LinkUp(phy_.LinkSpeed());
                 else if (linkState == services::SmiPhy::LinkState::Down)

--- a/hal_st/stm32fxxx/EthernetSmiStm.cpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.cpp
@@ -12,7 +12,7 @@ namespace hal
         hal::GpioPinStm& ethernetRmiiTxEn, hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint8_t phyAddress)
         : smiBus(ethernetMdio, ethernetMdc, ethernetRmiiRefClk, ethernetRmiiCrsDv, ethernetRmiiRxD0, ethernetRmiiRxD1, ethernetRmiiTxEn, ethernetRmiiTxD0, ethernetRmiiTxD1)
         , phyAddress(phyAddress)
-        , phy_(smiBus, phyAddress)
+        , phy(smiBus, phyAddress)
     {
         RunPhy();
     }
@@ -41,21 +41,21 @@ namespace hal
     {
         sequencer.Execute([this]()
             {
-                phy_.WriteBcr(infra::Bit<uint16_t>(services::SmiPhy::BasicControlRegister::ResetBit));
+                phy.WriteBcr(infra::Bit<uint16_t>(services::SmiPhy::BasicControlRegister::ResetBit));
             });
         sequencer.DoWhile();
         Delay(std::chrono::milliseconds(1));
         sequencer.Execute([this]()
             {
-                savedBcr_ = phy_.ReadBcr();
+                savedBcr = phy.ReadBcr();
             });
         sequencer.EndDoWhile([this]()
             {
-                return services::SmiPhy::BasicControlRegister::IsResetting(savedBcr_);
+                return services::SmiPhy::BasicControlRegister::IsResetting(savedBcr);
             });
         sequencer.Execute([this]()
             {
-                phy_.EnableAutoNegIfCapable();
+                phy.EnableAutoNegIfCapable();
             });
     }
 
@@ -63,13 +63,13 @@ namespace hal
     {
         sequencer.Execute([this]()
             {
-                const auto linkState = phy_.ReadLinkState();
-                if (linkState == lastLinkState_)
+                const auto linkState = phy.ReadLinkState();
+                if (linkState == lastLinkState)
                     return;
 
-                lastLinkState_ = linkState;
+                lastLinkState = linkState;
                 if (linkState == services::SmiPhy::LinkState::Up)
-                    GetObserver().LinkUp(phy_.LinkSpeed());
+                    GetObserver().LinkUp(phy.LinkSpeed());
                 else if (linkState == services::SmiPhy::LinkState::Down)
                 {
                     GetObserver().LinkDown();

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -6,6 +6,7 @@
 #include "hal_st/stm32fxxx/SmiBusStm.hpp"
 #include "infra/timer/Timer.hpp"
 #include "infra/util/Sequencer.hpp"
+#include "services/util/SmiPhy.hpp"
 
 namespace hal
 {
@@ -15,7 +16,7 @@ namespace hal
     public:
         EthernetSmiStm(hal::GpioPinStm& ethernetMdio, hal::GpioPinStm& ethernetMdc, hal::GpioPinStm& ethernetRmiiRefClk, hal::GpioPinStm& ethernetRmiiCrsDv,
             hal::GpioPinStm& ethernetRmiiRxD0, hal::GpioPinStm& ethernetRmiiRxD1, hal::GpioPinStm& ethernetRmiiTxEn,
-            hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint16_t phyAddress = 0);
+            hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint8_t phyAddress = 0);
         ~EthernetSmiStm();
 
     public:
@@ -25,43 +26,17 @@ namespace hal
         void RunPhy();
         void ResetPhy();
         void DetectLink();
-        LinkSpeed GetLinkSpeedNegotiated() const;
-        LinkSpeed GetLinkSpeedLocal() const;
-        uint16_t ReadPhyRegister(uint16_t reg) const;
-        void WritePhyRegister(uint16_t reg, uint16_t value);
         void Delay(infra::Duration duration);
 
     private:
         SmiBusStm smiBus;
-        uint16_t phyAddress;
+        uint8_t phyAddress;
+        services::SmiPhy phy_;
 
         infra::Sequencer sequencer;
-        uint32_t phyControlRegisterValue;
+        uint16_t savedBcr_ = 0;
         infra::TimerSingleShot delayTimer;
         infra::Duration delay;
-
-        bool autoNegotiation = false;
-        bool linkUp = false;
-
-        static const uint16_t phyBasicControlRegister = 0;
-        static const uint16_t phyBasicStatusRegister = 1;
-        static const uint16_t phyAutoNegotiationAdvertisement = 4;
-        static const uint16_t phyAutoNegotiationLinkPartnerAbility = 5;
-
-        static const uint16_t phyBcrDuplexMode = 8;
-        static const uint16_t phyBcrRestartAutoNegotiation = 9;
-        static const uint16_t phyBcrAutoNegotiationEnable = 12;
-        static const uint16_t phyBcrSpeedSelectLsb = 13;
-        static const uint16_t phyBcrReset = 15;
-
-        static const uint16_t phyBsrLinkUp = 2;
-        static const uint16_t phyBsrAutoNegotiationAbility = 3;
-        static const uint16_t phyBsrAutoNegotiationComplete = 5;
-
-        static const uint16_t phyAnlpaHalfDuplex10MHz = 5;
-        static const uint16_t phyAnlpaFullDuplex10MHz = 6;
-        static const uint16_t phyAnlpaHalfDuplex100MHz = 7;
-        static const uint16_t phyAnlpaFullDuplex100MHz = 8;
     };
 }
 

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -3,6 +3,7 @@
 
 #include "hal/interfaces/Ethernet.hpp"
 #include "hal_st/stm32fxxx/GpioStm.hpp"
+#include "hal_st/stm32fxxx/SmiBusStm.hpp"
 #include "infra/timer/Timer.hpp"
 #include "infra/util/Sequencer.hpp"
 
@@ -22,7 +23,6 @@ namespace hal
 
     private:
         void RunPhy();
-        void SetMiiClockRange();
         void ResetPhy();
         void DetectLink();
         LinkSpeed GetLinkSpeedNegotiated() const;
@@ -32,15 +32,7 @@ namespace hal
         void Delay(infra::Duration duration);
 
     private:
-        hal::PeripheralPinStm ethernetMdio;
-        hal::PeripheralPinStm ethernetMdc;
-        hal::PeripheralPinStm ethernetRmiiRefClk;
-        hal::PeripheralPinStm ethernetRmiiCrsDv;
-        hal::PeripheralPinStm ethernetRmiiRxD0;
-        hal::PeripheralPinStm ethernetRmiiRxD1;
-        hal::PeripheralPinStm ethernetRmiiTxEn;
-        hal::PeripheralPinStm ethernetRmiiTxD0;
-        hal::PeripheralPinStm ethernetRmiiTxD1;
+        SmiBusStm smiBus;
         uint16_t phyAddress;
 
         infra::Sequencer sequencer;

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -17,7 +17,6 @@ namespace hal
         EthernetSmiStm(hal::GpioPinStm& ethernetMdio, hal::GpioPinStm& ethernetMdc, hal::GpioPinStm& ethernetRmiiRefClk, hal::GpioPinStm& ethernetRmiiCrsDv,
             hal::GpioPinStm& ethernetRmiiRxD0, hal::GpioPinStm& ethernetRmiiRxD1, hal::GpioPinStm& ethernetRmiiTxEn,
             hal::GpioPinStm& ethernetRmiiTxD0, hal::GpioPinStm& ethernetRmiiTxD1, uint8_t phyAddress = 0);
-        ~EthernetSmiStm();
 
     public:
         uint16_t PhyAddress() const override;

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -36,6 +36,7 @@ namespace hal
         uint16_t savedBcr_ = 0;
         infra::TimerSingleShot delayTimer;
         infra::Duration delay;
+        services::SmiPhy::LinkState lastLinkState_ = services::SmiPhy::LinkState::Down;
     };
 }
 

--- a/hal_st/stm32fxxx/EthernetSmiStm.hpp
+++ b/hal_st/stm32fxxx/EthernetSmiStm.hpp
@@ -30,13 +30,13 @@ namespace hal
     private:
         SmiBusStm smiBus;
         uint8_t phyAddress;
-        services::SmiPhy phy_;
+        services::SmiPhy phy;
 
         infra::Sequencer sequencer;
-        uint16_t savedBcr_ = 0;
+        uint16_t savedBcr = 0;
         infra::TimerSingleShot delayTimer;
         infra::Duration delay;
-        services::SmiPhy::LinkState lastLinkState_ = services::SmiPhy::LinkState::Down;
+        services::SmiPhy::LinkState lastLinkState = services::SmiPhy::LinkState::Down;
     };
 }
 

--- a/hal_st/stm32fxxx/SmiBusStm.cpp
+++ b/hal_st/stm32fxxx/SmiBusStm.cpp
@@ -1,0 +1,125 @@
+#include "hal_st/stm32fxxx/SmiBusStm.hpp"
+#include DEVICE_HEADER
+#include "generated/stm32fxxx/PeripheralTable.hpp"
+#include <cstdlib>
+
+#if defined(HAS_PERIPHERAL_ETHERNET)
+
+namespace hal
+{
+    SmiBusStm::SmiBusStm(GpioPinStm& ethernetMdio, GpioPinStm& ethernetMdc, GpioPinStm& ethernetRmiiRefClk,
+        GpioPinStm& ethernetRmiiCrsDv, GpioPinStm& ethernetRmiiRxD0, GpioPinStm& ethernetRmiiRxD1,
+        GpioPinStm& ethernetRmiiTxEn, GpioPinStm& ethernetRmiiTxD0, GpioPinStm& ethernetRmiiTxD1)
+        : ethernetMdio(ethernetMdio, PinConfigTypeStm::ethernet, 0)
+        , ethernetMdc(ethernetMdc, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiRefClk(ethernetRmiiRefClk, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiCrsDv(ethernetRmiiCrsDv, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiRxD0(ethernetRmiiRxD0, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiRxD1(ethernetRmiiRxD1, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiTxEn(ethernetRmiiTxEn, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiTxD0(ethernetRmiiTxD0, PinConfigTypeStm::ethernet, 0)
+        , ethernetRmiiTxD1(ethernetRmiiTxD1, PinConfigTypeStm::ethernet, 0)
+    {
+#if !defined(STM32H5)
+        __HAL_RCC_SYSCFG_CLK_ENABLE();
+        SYSCFG->PMC |= SYSCFG_PMC_MII_RMII_SEL; // Select RMII Mode
+#else
+        __HAL_RCC_SBS_CLK_ENABLE();
+        SBS->PMCR |= SBS_ETH_RMII; // Select RMII Mode
+        (void)SBS->PMCR;           // Dummy read to sync with ETH
+#endif
+
+        EnableClockEthernet(0);
+        SetMiiClockRange();
+    }
+
+    SmiBusStm::~SmiBusStm()
+    {
+        DisableClockEthernet(0);
+    }
+
+    void SmiBusStm::SetMiiClockRange()
+    {
+        const uint32_t hclk = HAL_RCC_GetHCLKFreq();
+
+#if defined(STM32H5)
+        if (hclk >= 20000000 && hclk < 35000000)
+            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV16;
+        else if (hclk >= 35000000 && hclk < 60000000)
+            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV26;
+        else if (hclk >= 60000000 && hclk < 100000000)
+            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV42;
+        else if (hclk >= 100000000 && hclk < 150000000)
+            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV62;
+        else if (hclk >= 150000000 && hclk <= 250000000)
+            peripheralEthernet[0]->MACMDIOAR = ETH_MACMDIOAR_CR_DIV102;
+        else
+            std::abort();
+#else
+        if (hclk >= 20000000 && hclk < 35000000)
+            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div16;
+        else if (hclk >= 35000000 && hclk < 60000000)
+            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div26;
+        else if (hclk >= 60000000 && hclk < 100000000)
+            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div42;
+        else if (hclk >= 100000000 && hclk < 150000000)
+            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div62;
+        else if (hclk >= 150000000 && hclk <= 216000000)
+            peripheralEthernet[0]->MACMIIAR = ETH_MACMIIAR_CR_Div102;
+        else
+            std::abort();
+#endif
+    }
+
+    uint16_t SmiBusStm::Read(uint8_t phyAddress, uint16_t reg) const
+    {
+#if defined(STM32H5)
+        peripheralEthernet[0]->MACMDIOAR = (peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_CR) |
+                                           ((static_cast<uint32_t>(phyAddress) << 21) & ETH_MACMDIOAR_PA) |
+                                           ((static_cast<uint32_t>(reg) << 16) & ETH_MACMDIOAR_RDA) |
+                                           ETH_MACMDIOAR_MOC_RD | ETH_MACMDIOAR_MB;
+
+        while ((peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_MB) != 0)
+        {
+        }
+
+        return static_cast<uint16_t>(peripheralEthernet[0]->MACMDIODR);
+#else
+        peripheralEthernet[0]->MACMIIAR = (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_CR) |
+                                          ((static_cast<uint32_t>(phyAddress) << 11) & ETH_MACMIIAR_PA) |
+                                          ((static_cast<uint32_t>(reg) << 6) & ETH_MACMIIAR_MR) | ETH_MACMIIAR_MB;
+
+        while ((peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_MB) != 0)
+        {
+        }
+
+        return static_cast<uint16_t>(peripheralEthernet[0]->MACMIIDR);
+#endif
+    }
+
+    void SmiBusStm::Write(uint8_t phyAddress, uint16_t reg, uint16_t value)
+    {
+#if defined(STM32H5)
+        peripheralEthernet[0]->MACMDIODR = value;
+        peripheralEthernet[0]->MACMDIOAR = (peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_CR) |
+                                           ((static_cast<uint32_t>(phyAddress) << 21) & ETH_MACMDIOAR_PA) |
+                                           ((static_cast<uint32_t>(reg) << 16) & ETH_MACMDIOAR_RDA) |
+                                           ETH_MACMDIOAR_MOC_WR | ETH_MACMDIOAR_MB;
+
+        while ((peripheralEthernet[0]->MACMDIOAR & ETH_MACMDIOAR_MB) != 0)
+        {
+        }
+#else
+        peripheralEthernet[0]->MACMIIDR = value;
+        peripheralEthernet[0]->MACMIIAR = (peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_CR) |
+                                          ((static_cast<uint32_t>(phyAddress) << 11) & ETH_MACMIIAR_PA) |
+                                          ((static_cast<uint32_t>(reg) << 6) & ETH_MACMIIAR_MR) | ETH_MACMIIAR_MW | ETH_MACMIIAR_MB;
+
+        while ((peripheralEthernet[0]->MACMIIAR & ETH_MACMIIAR_MB) != 0)
+        {
+        }
+#endif
+    }
+}
+
+#endif

--- a/hal_st/stm32fxxx/SmiBusStm.hpp
+++ b/hal_st/stm32fxxx/SmiBusStm.hpp
@@ -1,0 +1,37 @@
+#ifndef HAL_SMI_BUS_STM_HPP
+#define HAL_SMI_BUS_STM_HPP
+
+#include "hal/interfaces/SmiBus.hpp"
+#include "hal_st/stm32fxxx/GpioStm.hpp"
+#include <cstdint>
+
+namespace hal
+{
+    class SmiBusStm
+        : public SmiBus
+    {
+    public:
+        SmiBusStm(GpioPinStm& ethernetMdio, GpioPinStm& ethernetMdc, GpioPinStm& ethernetRmiiRefClk,
+            GpioPinStm& ethernetRmiiCrsDv, GpioPinStm& ethernetRmiiRxD0, GpioPinStm& ethernetRmiiRxD1,
+            GpioPinStm& ethernetRmiiTxEn, GpioPinStm& ethernetRmiiTxD0, GpioPinStm& ethernetRmiiTxD1);
+        ~SmiBusStm() override;
+
+        uint16_t Read(uint8_t phyAddress, uint16_t reg) const override;
+        void Write(uint8_t phyAddress, uint16_t reg, uint16_t value) override;
+
+        void SetMiiClockRange();
+
+    private:
+        PeripheralPinStm ethernetMdio;
+        PeripheralPinStm ethernetMdc;
+        PeripheralPinStm ethernetRmiiRefClk;
+        PeripheralPinStm ethernetRmiiCrsDv;
+        PeripheralPinStm ethernetRmiiRxD0;
+        PeripheralPinStm ethernetRmiiRxD1;
+        PeripheralPinStm ethernetRmiiTxEn;
+        PeripheralPinStm ethernetRmiiTxD0;
+        PeripheralPinStm ethernetRmiiTxD1;
+    };
+}
+
+#endif

--- a/hal_st/stm32fxxx/SmiBusStm.hpp
+++ b/hal_st/stm32fxxx/SmiBusStm.hpp
@@ -14,7 +14,7 @@ namespace hal
         SmiBusStm(GpioPinStm& ethernetMdio, GpioPinStm& ethernetMdc, GpioPinStm& ethernetRmiiRefClk,
             GpioPinStm& ethernetRmiiCrsDv, GpioPinStm& ethernetRmiiRxD0, GpioPinStm& ethernetRmiiRxD1,
             GpioPinStm& ethernetRmiiTxEn, GpioPinStm& ethernetRmiiTxD0, GpioPinStm& ethernetRmiiTxD1);
-        ~SmiBusStm() override;
+        ~SmiBusStm();
 
         uint16_t Read(uint8_t phyAddress, uint16_t reg) const override;
         void Write(uint8_t phyAddress, uint16_t reg, uint16_t value) override;

--- a/hal_st_lwip/instantiations_lwip/EthernetSmiObserver.cpp
+++ b/hal_st_lwip/instantiations_lwip/EthernetSmiObserver.cpp
@@ -17,7 +17,7 @@ namespace main_
 
     void EthernetSmiObserver::LinkUp(hal::LinkSpeed linkSpeed)
     {
-        ethernetMac.emplace(Subject(), linkSpeed, lightweightIpOverEthernetFactory.MacAddress());
+        ethernetMac.emplace(linkSpeed, lightweightIpOverEthernetFactory.MacAddress());
 #if STM32F767xx
         ethernetStm32f767Workaround.emplace(*ethernetMac, ethernetRmiiRefClk, ethernetRmiiRefClkPeripheral);
         lightweightIpOverEthernetFactory.Create(*ethernetStm32f767Workaround);


### PR DESCRIPTION
Introduces a new `SmiBusStm` driver implementing the `hal::SmiBus` interface from amp-embedded-infra-lib, and refactors the STM32 Ethernet stack so that PHY management is no longer coupled to `EthernetMacStm`. PHY handling now goes through the generic `SmiPhy` from amp-embedded-infra-lib instead of the STM32-specific `EthernetSmiStm`.

### Changes

- **New** `hal_st/stm32fxxx/SmiBusStm.hpp` / `SmiBusStm.cpp`: STM32 implementation of `hal::SmiBus`, owning the MDIO/MDC and RMII peripheral pin configuration and providing `Read` / `Write` over the SMI bus.
- **Refactor** `hal_st/stm32fxxx/EthernetMacStm.hpp` / `EthernetMacStm.cpp`: Remove the `EthernetSmi` dependency; the MAC no longer drives PHY register access.
- **Refactor** `hal_st/stm32fxxx/EthernetMacH5xxStm.cpp`: Adjusted to match the new MAC interface.
- **Slim down** `hal_st/stm32fxxx/EthernetSmiStm.hpp` / `EthernetSmiStm.cpp`: Functionality replaced by `SmiBusStm` + `SmiPhy` from amp-embedded-infra-lib (~160 lines removed).
- **Update** `hal_st_lwip/instantiations_lwip/EthernetSmiObserver.cpp`: Adapt to the new interface.
- **Build** `hal_st/stm32fxxx/CMakeLists.txt`: Register the new sources.

### Motivation

Decoupling the SMI bus from the MAC and Ethernet-specific PHY logic enables reusing the generic `SmiPhy` driver from amp-embedded-infra-lib, reduces duplication in the STM32 HAL, and simplifies supporting additional PHY chips without touching the MAC driver.
