### PR TITLE
feat: disable filterDuplicatesEnabled in GapCentralSt

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -22,7 +22,7 @@ namespace hal
     const uint16_t maxConnectionEventLength = 0x280; // 400 ms
 
     // Discovery parameters
-    const uint8_t filterDuplicatesEnabled = 1;
+    const uint8_t filterDuplicatesEnabled = 0;
     const uint8_t acceptParameters = 1;
     const uint8_t rejectParameters = 0;
 


### PR DESCRIPTION
filterDuplicates in GapCentralSt seems to filter with time, instead of with some kind of special de-duplication algorithm.
The real implementation seems to be hidden. I cannot discern a way to change how it works, I believe that we can only enable/disable the behaviour.

Tests seem to imply that its about a 150-300ms window, of which 'duplicate' broadcasts are ignored.
Broadcasts do not have much unique data other than timestamp, just addresses & the packet data.

By setting this to 0, you can be more confident that a matching peripherals' advertising interval is read at the correct rate.
I.e., you can set a peripheral to advertise every 50/500ms, and actually expect to see that on the central side. 
When this was set to 1, the same advertisement packets may be seen to come in at 150-300 and 300-700ms intervals, respectively.