### PR TITLE
chore: remove notifying observers of standby state

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -51,14 +51,6 @@ namespace hal
         , security(configuration.security)
     {
         Initialize(configuration);
-
-        infra::EventDispatcher::Instance().Schedule([this]
-            {
-                infra::Subject<services::GapCentralObserver>::NotifyObservers([](auto& observer)
-                    {
-                        observer.StateChanged(services::GapState::standby);
-                    });
-            });
     }
 
     void GapCentralSt::Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout)


### PR DESCRIPTION
The publishing of the `GapState::Standby` is not the job of the HAL layer.