### PR TITLE
feat: make WatchDogStm config initializable as aggregate

### DIFF
--- a/hal_st/stm32fxxx/WatchDogStm.hpp
+++ b/hal_st/stm32fxxx/WatchDogStm.hpp
@@ -8,14 +8,10 @@
 
 namespace hal
 {
-    class WatchDogStm
+    namespace detail
     {
-    public:
-        struct Config
+        struct WatchDogStmConfig
         {
-            constexpr Config()
-            {}
-
             // WWDG clock (Hz) = PCLK1 / (4096 * Prescaler)                     --> 54Mhz / 32768 = 1728 Hz
             // WWDG timeout (mS) = 1000 * Counter / WWDG clock                  -->  73 ms
             // WWDG Counter refresh is allowed between the following limits :
@@ -26,6 +22,12 @@ namespace hal
             infra::Duration feedTimerInterval{ std::chrono::milliseconds(25) };
             uint32_t maxMissedFeeds{ 41 };
         };
+    }
+
+    class WatchDogStm
+    {
+    public:
+        using Config = detail::WatchDogStmConfig;
 
         WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config());
 


### PR DESCRIPTION
By pulling the Config struct out of the WatchDogStm class, it does not need a non-default constructor, is therefore an aggregate, and can therefore be used with aggregate member initialization