### PR TITLE
fix: refresh bond aging on reconnect and normalize resolved identity address type

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -33,8 +33,20 @@ namespace hal
                 }
         }
 
-        constexpr auto publicIdentityAddress = static_cast<services::GapDeviceAddressType>(2);
-        constexpr auto randomIdentityAddress = static_cast<services::GapDeviceAddressType>(3);
+        services::GapDeviceAddressType ToDeviceAddressType(HciPeerAddressType peerAddressType)
+        {
+            switch (peerAddressType)
+            {
+                case HciPeerAddressType::publicDeviceAddress:
+                case HciPeerAddressType::publicIdentityAddress:
+                    return services::GapDeviceAddressType::publicAddress;
+                case HciPeerAddressType::randomDeviceAddress:
+                case HciPeerAddressType::randomIdentityAddress:
+                    return services::GapDeviceAddressType::randomAddress;
+            }
+
+            LOG_AND_ABORT_ENUM(peerAddressType);
+        }
     }
 
     GapSt::GapSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration)
@@ -249,7 +261,7 @@ namespace hal
     {
         if (event.Status == BLE_STATUS_SUCCESS)
         {
-            SetConnectionContext(event.Connection_Handle, static_cast<services::GapDeviceAddressType>(event.Peer_Address_Type), &event.Peer_Address[0]);
+            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(static_cast<HciPeerAddressType>(event.Peer_Address_Type)), &event.Peer_Address[0]);
             UpdateBondAgingForConnectedPeer();
         }
     }
@@ -258,7 +270,7 @@ namespace hal
     {
         if (event.Status == BLE_STATUS_SUCCESS)
         {
-            SetConnectionContext(event.Connection_Handle, static_cast<services::GapDeviceAddressType>(event.Peer_Address_Type), &event.Peer_Address[0]);
+            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(static_cast<HciPeerAddressType>(event.Peer_Address_Type)), &event.Peer_Address[0]);
             UpdateBondAgingForConnectedPeer();
         }
     }
@@ -418,13 +430,7 @@ namespace hal
 
     bool GapSt::UpdateBondAgingForConnectedPeer()
     {
-        auto addressType = connectionContext.peerAddressType;
-        if (addressType == publicIdentityAddress)
-            addressType = services::GapDeviceAddressType::publicAddress;
-        else if (addressType == randomIdentityAddress)
-            addressType = services::GapDeviceAddressType::randomAddress;
-
-        if (!IsDeviceBonded(connectionContext.peerAddress, addressType))
+        if (!IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
             return false;
 
         hal::MacAddress address = connectionContext.peerAddress;

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -245,13 +245,19 @@ namespace hal
     void GapSt::HandleHciLeConnectionCompleteEvent(const hci_le_connection_complete_event_rp0& event)
     {
         if (event.Status == BLE_STATUS_SUCCESS)
+        {
             SetConnectionContext(event.Connection_Handle, static_cast<services::GapDeviceAddressType>(event.Peer_Address_Type), &event.Peer_Address[0]);
+            UpdateBondAgingForConnectedPeer();
+        }
     }
 
     void GapSt::HandleHciLeEnhancedConnectionCompleteEvent(const hci_le_enhanced_connection_complete_event_rp0& event)
     {
         if (event.Status == BLE_STATUS_SUCCESS)
+        {
             SetConnectionContext(event.Connection_Handle, static_cast<services::GapDeviceAddressType>(event.Peer_Address_Type), &event.Peer_Address[0]);
+            UpdateBondAgingForConnectedPeer();
+        }
     }
 
     void GapSt::HandleBondLostEvent()
@@ -274,13 +280,8 @@ namespace hal
     {
         really_assert(event.Connection_Handle == connectionContext.connectionHandle);
 
-        if (IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
-        {
-            hal::MacAddress address = connectionContext.peerAddress;
-            aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), address.data());
-            bondStorageSynchronizer.UpdateBondedDevice(address);
+        if (UpdateBondAgingForConnectedPeer())
             UpdateNrBonds();
-        }
 
         auto pairedSuccessfully = event.Status == SMP_PAIRING_STATUS_SUCCESS;
         auto pairingFailedReason = pairedSuccessfully ? services::GapPairingObserver::PairingFailedReason::unknown : ParserPairingFailure(event.Status, event.Reason);
@@ -410,5 +411,17 @@ namespace hal
             {
                 obs.NumberOfBondsChanged(nrBonds);
             });
+    }
+
+    bool GapSt::UpdateBondAgingForConnectedPeer()
+    {
+        if (!IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
+            return false;
+
+        hal::MacAddress address = connectionContext.peerAddress;
+        aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), address.data());
+        bondStorageSynchronizer.UpdateBondedDevice(address);
+
+        return true;
     }
 }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -32,6 +32,9 @@ namespace hal
                         return services::GapPairingObserver::PairingFailedReason::unknown;
                 }
         }
+
+        constexpr auto publicIdentityAddress = static_cast<services::GapDeviceAddressType>(2);
+        constexpr auto randomIdentityAddress = static_cast<services::GapDeviceAddressType>(3);
     }
 
     GapSt::GapSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration)
@@ -415,11 +418,11 @@ namespace hal
 
     bool GapSt::UpdateBondAgingForConnectedPeer()
     {
-        constexpr uint8_t resolvedIdentityAddressTypeOffset = 2;
-        auto peerAddressType = static_cast<uint8_t>(connectionContext.peerAddressType);
-        auto addressType = peerAddressType >= resolvedIdentityAddressTypeOffset
-                               ? static_cast<services::GapDeviceAddressType>(peerAddressType - resolvedIdentityAddressTypeOffset)
-                               : connectionContext.peerAddressType;
+        auto addressType = connectionContext.peerAddressType;
+        if (addressType == publicIdentityAddress)
+            addressType = services::GapDeviceAddressType::publicAddress;
+        else if (addressType == randomIdentityAddress)
+            addressType = services::GapDeviceAddressType::randomAddress;
 
         if (!IsDeviceBonded(connectionContext.peerAddress, addressType))
             return false;

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -415,7 +415,13 @@ namespace hal
 
     bool GapSt::UpdateBondAgingForConnectedPeer()
     {
-        if (!IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
+        constexpr uint8_t resolvedIdentityAddressTypeOffset = 2;
+        auto peerAddressType = static_cast<uint8_t>(connectionContext.peerAddressType);
+        auto addressType = peerAddressType >= resolvedIdentityAddressTypeOffset
+                               ? static_cast<services::GapDeviceAddressType>(peerAddressType - resolvedIdentityAddressTypeOffset)
+                               : connectionContext.peerAddressType;
+
+        if (!IsDeviceBonded(connectionContext.peerAddress, addressType))
             return false;
 
         hal::MacAddress address = connectionContext.peerAddress;

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -4,6 +4,7 @@
 #include "ble_types.h"
 #include "infra/event/EventDispatcherWithWeakPtr.hpp"
 #include "services/ble/Gap.hpp"
+#include <cstdint>
 
 namespace hal
 {
@@ -33,15 +34,15 @@ namespace hal
                 }
         }
 
-        services::GapDeviceAddressType ToDeviceAddressType(HciPeerAddressType peerAddressType)
+        services::GapDeviceAddressType ToDeviceAddressType(uint8_t peerAddressType)
         {
             switch (peerAddressType)
             {
-                case HciPeerAddressType::publicDeviceAddress:
-                case HciPeerAddressType::publicIdentityAddress:
+                case 0: // public device address
+                case 2: // public identity address
                     return services::GapDeviceAddressType::publicAddress;
-                case HciPeerAddressType::randomDeviceAddress:
-                case HciPeerAddressType::randomIdentityAddress:
+                case 1: // random device address
+                case 3: // random identity address
                     return services::GapDeviceAddressType::randomAddress;
             }
 
@@ -261,7 +262,7 @@ namespace hal
     {
         if (event.Status == BLE_STATUS_SUCCESS)
         {
-            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(static_cast<HciPeerAddressType>(event.Peer_Address_Type)), &event.Peer_Address[0]);
+            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(event.Peer_Address_Type), &event.Peer_Address[0]);
             UpdateBondAgingForConnectedPeer();
         }
     }
@@ -270,7 +271,7 @@ namespace hal
     {
         if (event.Status == BLE_STATUS_SUCCESS)
         {
-            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(static_cast<HciPeerAddressType>(event.Peer_Address_Type)), &event.Peer_Address[0]);
+            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(event.Peer_Address_Type), &event.Peer_Address[0]);
             UpdateBondAgingForConnectedPeer();
         }
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -262,7 +262,7 @@ namespace hal
     {
         if (event.Status == BLE_STATUS_SUCCESS)
         {
-            SetConnectionContext(event.Connection_Handle, ToDeviceAddressType(event.Peer_Address_Type), &event.Peer_Address[0]);
+            SetConnectionContext(event.Connection_Handle, static_cast<services::GapDeviceAddressType>(event.Peer_Address_Type), &event.Peer_Address[0]);
             UpdateBondAgingForConnectedPeer();
         }
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -11,6 +11,14 @@
 
 namespace hal
 {
+    enum class HciPeerAddressType : uint8_t
+    {
+        publicDeviceAddress = 0,
+        randomDeviceAddress = 1,
+        publicIdentityAddress = 2,
+        randomIdentityAddress = 3,
+    };
+
     class GapSt
         : public services::AttMtuExchangeImpl
         , public services::GapBonding

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -11,14 +11,6 @@
 
 namespace hal
 {
-    enum class HciPeerAddressType : uint8_t
-    {
-        publicDeviceAddress = 0,
-        randomDeviceAddress = 1,
-        publicIdentityAddress = 2,
-        randomIdentityAddress = 3,
-    };
-
     class GapSt
         : public services::AttMtuExchangeImpl
         , public services::GapBonding

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -114,6 +114,7 @@ namespace hal
 
         void SetConnectionContext(uint16_t connectionHandle, services::GapDeviceAddressType peerAddressType, const uint8_t* peerAddress);
         void UpdateNrBonds();
+        bool UpdateBondAgingForConnectedPeer();
 
     protected:
         struct ConnectionContext


### PR DESCRIPTION
# Description of changes

Fixes bond aging (LRU eviction) on the ST BLE peripheral. When the bond storage was
full, the device evicted the **first-bonded** central instead of the
**least-recently-connected** one, because the aging order was never refreshed when an
already-bonded central reconnected.

## Root cause
Both parts live in the shared ST GAP layer `GapSt`:

1. The aging order in `BondStorageWithAging` was only refreshed on a **new pairing**
   (`HandlePairingCompleteEvent`). On **reconnection** of an already-bonded central (no
   re-pairing) the order was never updated, so the "oldest" entry stayed the first-bonded
   device instead of the least-recently-connected one — and `RemoveOldestBond()` evicted
   the wrong device.
2. After refreshing aging on connection-complete, reconnections still failed the bonded
   check: the controller reports a reconnected peer with a **resolved identity address
   type** (2 = public identity, 3 = random identity), but `aci_gap_is_device_bonded()`
   only matches the base types (0/1). So `IsDeviceBonded` returned false and the refresh
   was skipped.

## Fix
- New `GapSt::UpdateBondAgingForConnectedPeer()`: normalizes the resolved identity address
  type (2/3 → 0/1), checks `IsDeviceBonded`, resolves the private address, and calls
  `bondStorageSynchronizer.UpdateBondedDevice()` to move the peer to the most-recent slot.
- Invoked from both `HandleHciLeConnectionCompleteEvent` and
  `HandleHciLeEnhancedConnectionCompleteEvent` (reconnections now refresh aging), and
  reused in `HandlePairingCompleteEvent`.
- Located in the shared `GapSt` base → covers ST BLE Peripheral **Integrated** and
  **Offloaded** (and Central).

The `BondStorageWithAging` container (move-to-back / evict-front) was already correct and
is covered by existing Host unit tests; only the `GapSt` refresh was missing/blocked.

## Validation
Tested on STM32WB55 (`st_ble.node_integrated`), max bonds temporarily lowered to 2 to test
with 3 phones (A/B/C):

| Step | Aging order |
|---|---|
| Bond A | `[A]` |
| Bond B | `[A, B]` |
| Reconnect A | `[B, A]` (A moved to most-recent) |
| Bond C | `[A, C]` (B — the true oldest — evicted) |

Before the fix the reconnect did not update the order and A (first-bonded) was wrongly
evicted → `[B, C]`.