### PR TITLE
fix: provide newlib syscall stubs for GCC 15+ toolchains

### DIFF
--- a/hal_st/default_init/CMakeLists.txt
+++ b/hal_st/default_init/CMakeLists.txt
@@ -20,6 +20,12 @@ target_sources(hal_st.default_init PRIVATE
     DefaultInit.cpp
 )
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+    target_sources(hal_st.default_init PRIVATE
+        SysCallStubs.cpp
+    )
+endif()
+
 if (TARGET_MCU_VENDOR STREQUAL st)
     get_target_property(startup_source st.hal_driver_${TARGET_MCU_FAMILY} HALST_STARTUP_SOURCE)
 

--- a/hal_st/default_init/CMakeLists.txt
+++ b/hal_st/default_init/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(hal_st.default_init PRIVATE
     DefaultInit.cpp
 )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     target_sources(hal_st.default_init PRIVATE
         SysCallStubs.cpp
     )

--- a/hal_st/default_init/SysCallStubs.cpp
+++ b/hal_st/default_init/SysCallStubs.cpp
@@ -1,0 +1,54 @@
+#include <cerrno>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+extern "C"
+{
+    __attribute__((weak)) int _close([[maybe_unused]] int fildes)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _fstat([[maybe_unused]] int fildes, [[maybe_unused]] struct stat* st)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _getpid()
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _isatty([[maybe_unused]] int file)
+    {
+        errno = ENOSYS;
+        return 0;
+    }
+
+    __attribute__((weak)) int _kill([[maybe_unused]] int pid, [[maybe_unused]] int sig)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _lseek([[maybe_unused]] int file, [[maybe_unused]] int ptr, [[maybe_unused]] int dir)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _read([[maybe_unused]] int file, [[maybe_unused]] char* ptr, [[maybe_unused]] int len)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+
+    __attribute__((weak)) int _write([[maybe_unused]] int file, [[maybe_unused]] char* ptr, [[maybe_unused]] int len)
+    {
+        errno = ENOSYS;
+        return -1;
+    }
+}


### PR DESCRIPTION
Newlib-nano does not implement the POSIX OS-interface subroutines (_close, _fstat, _getpid, _isatty, _kill, _lseek, _read, _write); they must be supplied by the application, a BSP, or via --specs=nosys.specs. The newlib manual lists these explicitly as stubs that a bare-metal target has to provide to allow libc to link [1][2].

libstdc++ enables precondition assertions via _GLIBCXX_ASSERTIONS, which is defined by default in unoptimized (Debug) builds [3]. With the bumped toolchain (arm-none-eabi-gcc 15) a failed assertion is reported through std::__glibcxx_assert_fail, whose implementation calls fprintf. This newly drags newlib's stdio backend into the image, which references the reentrant covers _read_r, _write_r, _close_r, etc.; those in turn reference the underlying _close, _fstat, _isatty, _lseek, _read and _write. Because the image did not pull in stdio before, the missing stubs went unnoticed; now linking fails with "undefined reference to _close/_lseek/_read/_write/_fstat/_isatty" and the accompanying "dangerous relocation: unsupported relocation" errors (caused by the undefined symbols resolving to absolute 0).

Add SysCallStubs.cpp providing weak, ENOSYS-returning implementations of these syscalls so the image links regardless of what drags in stdio. _getpid and _kill are included defensively (e.g. for the abort/raise path) though not currently referenced. The stubs are weak so applications can still override them with real implementations, and are only compiled for GCC 15 and newer.

[1] Newlib manual, "System Calls":
    https://sourceware.org/newlib/libc.html#Syscalls
[2] Newlib manual, per-function "Supporting OS subroutines required"
    (e.g. assert, printf/fprintf): https://sourceware.org/newlib/libc.html
[3] libstdc++ manual, "Macros" (_GLIBCXX_ASSERTIONS):
    https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_macros.html