### PR TITLE
[ignore] fix: raise central connection supervision timeout to 3000ms

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -14,7 +14,7 @@ namespace hal
         6, // 7.5 ms
         6, // 7.5 ms
         0,
-        50, // 500 ms
+        300, // 3000 ms
     };
 
     // Connection Interval parameters


### PR DESCRIPTION
this is an experiment. probably does not need merging.
another peripheral i'm using seems to stay unresponsive for > a second or whatever during pairing, and increasing this timeout seems to help.
imo thats a symptom of something else, but i dont know what it is yet.