### PR TITLE
ci: embedded build on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/philips-software/amp-devcontainer-cpp:8.1.0@sha256:740110a1a70c336d5b4a2770f84b9d856839ca90a04fec8f0300828e98cb9518
+FROM ghcr.io/philips-software/amp-devcontainer-embedded-cpp:v8.1.0@sha256:4bd90db36865cdee2ee9a41bd100c2078e3b3f75d4bdd307e404b90cae8b4415
 
 HEALTHCHECK NONE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
   embedded_build_devcontainer:
     name: Embedded Build on devcontainer
     runs-on: ubuntu-latest
-    container: ghcr.io/philips-software/amp-devcontainer-cpp:pr-1380
+    container: ghcr.io/philips-software/amp-devcontainer-embedded-cpp:pr-1380
     needs: [host_build_test_ubuntu]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,48 @@ jobs:
           name: hal_st_tested_stm32f767
           path: build/stm32f767/integration_test/tested/RelWithDebInfo/integration_test.tested.bin
 
+  embedded_build_devcontainer:
+    name: Embedded Build on devcontainer
+    runs-on: ubuntu-latest
+    container: ghcr.io/philips-software/amp-devcontainer-cpp:pr-1380
+    needs: [host_build_test_ubuntu]
+    strategy:
+      matrix:
+        configuration: ["RelWithDebInfo"]
+        gcc: ["10.3-2021.10"]
+        target:
+          [
+            "stm32wb55",
+            "stm32wba52",
+            "stm32wba65",
+            "stm32g070",
+            "stm32g071",
+            "stm32g431",
+            "stm32f407",
+            "stm32f429",
+            "stm32f746",
+            "stm32f767",
+            "stm32h563",
+            "stm32h573"
+          ]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        with:
+          key: ${{ matrix.gcc }}-${{ matrix.configuration }}-${{ matrix.target }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: hal_st
+      - run: tar -zxvf hal_st-*.tar.gz
+      - run: mkdir install && mv hal_st-*/* install/
+      - uses: lukka/run-cmake@5d55ea7949e25f69f0ecb516d8d572297e03a956 # v10.9
+        with:
+          configurePreset: ${{ matrix.target }}
+          buildPreset: ${{ matrix.target }}-${{ matrix.configuration }}
+          configurePresetAdditionalArgs: "['-DCMAKE_C_COMPILER_LAUNCHER=ccache', '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache']"
+
   integration_test:
     name: Integration test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
   embedded_build_devcontainer:
     name: Embedded Build on devcontainer
     runs-on: ubuntu-latest
-    container: ghcr.io/philips-software/amp-devcontainer-embedded-cpp:pr-1380
+    container: ghcr.io/philips-software/amp-devcontainer-embedded-cpp:4bd90db36865cdee2ee9a41bd100c2078e3b3f75d4bdd307e404b90cae8b4415 # v8.1.0
     needs: [host_build_test_ubuntu]
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
   embedded_build_devcontainer:
     name: Embedded Build on devcontainer
     runs-on: ubuntu-latest
-    container: ghcr.io/philips-software/amp-devcontainer-embedded-cpp:4bd90db36865cdee2ee9a41bd100c2078e3b3f75d4bdd307e404b90cae8b4415 # v8.1.0
+    container: ghcr.io/philips-software/amp-devcontainer-embedded-cpp:v8.1.0@sha256:4bd90db36865cdee2ee9a41bd100c2078e3b3f75d4bdd307e404b90cae8b4415 # v8.1.0
     needs: [host_build_test_ubuntu]
     strategy:
       matrix:


### PR DESCRIPTION
Fixes #849 

This pull request adds a new CI job to build embedded targets inside a development container, improving consistency and reproducibility of the embedded build process. The new job leverages a pre-built devcontainer image and runs builds for multiple STM32 targets using a matrix strategy.

**CI/CD improvements:**

* Added a new `embedded_build_devcontainer` job to `.github/workflows/ci.yml` that builds embedded targets inside a devcontainer using the `ghcr.io/philips-software/amp-devcontainer-embedded-cpp:pr-1380` image, ensuring a consistent build environment.
* Configured the job to use a build matrix covering multiple STM32 targets, GCC version `10.3-2021.10`, and the `RelWithDebInfo` configuration for comprehensive coverage.
* Integrated caching with `ccache` and artifact downloading to optimize build performance and reuse dependencies.
* Utilized `lukka/run-cmake` for standardized CMake configuration and build steps, with support for ccache as a compiler launcher.