### PR TITLE
fix: improve the RNG handle for WBA

### DIFF
--- a/hal_st/synchronous_stm32fxxx/SynchronousRandomDataGeneratorStm.cpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousRandomDataGeneratorStm.cpp
@@ -8,11 +8,22 @@ namespace hal
     SynchronousRandomDataGeneratorStm::SynchronousRandomDataGeneratorStm()
     {
         __HAL_RCC_RNG_CLK_ENABLE();
+
+#if defined(RNG_CR_CONDRST)
+        RNG->CR |= RNG_CR_IE;
+#endif
         RNG->CR |= RNG_CR_RNGEN;
+#if defined(RNG_CR_CONDRST)
+        if ((RNG->CR & RNG_CR_CONDRST) != 0)
+            Reset();
+#endif
     }
 
     SynchronousRandomDataGeneratorStm::~SynchronousRandomDataGeneratorStm()
     {
+#if defined(RNG_CR_CONDRST)
+        RNG->CR &= ~RNG_CR_IE;
+#endif
         RNG->CR &= ~RNG_CR_RNGEN;
         __HAL_RCC_RNG_CLK_DISABLE();
     }
@@ -27,12 +38,13 @@ namespace hal
             if ((RNG->SR & RNG_SR_SEIS) != 0)
             {
                 // Seed error, reset RNG and try again
-                static_cast<void>(RNG->DR);
-                RNG->SR &= ~RNG_SR_SEIS;
-                RNG->CR &= ~RNG_CR_RNGEN;
-                RNG->CR |= RNG_CR_RNGEN;
-                RNG->CR |= RNG_CR_IE;
+                Reset();
             }
+
+#if defined(RNG_CR_CONDRST)
+            if ((RNG->CR & RNG_CR_CONDRST) != 0)
+                Reset();
+#endif
 
             if ((RNG->SR & RNG_SR_DRDY) != 0)
             {
@@ -45,6 +57,31 @@ namespace hal
             }
         }
     }
-}
 
+    void SynchronousRandomDataGeneratorStm::Reset()
+    {
+#if defined(RNG_CR_CONDRST)
+        RNG->CR &= ~RNG_CR_IE;
+        RNG->CR &= ~RNG_CR_RNGEN;
+#if defined(RNG_SR_BUSY)
+        RNG->SR &= ~RNG_SR_BUSY;
+#endif
+        RNG->CR |= RNG_CR_CONDRST;
+        RNG->CR &= ~RNG_CR_CONDRST;
+
+        while ((RNG->CR & RNG_CR_CONDRST) != 0)
+        {
+        }
+        RNG->SR &= ~RNG_SR_SEIS;
+        RNG->CR |= RNG_CR_IE;
+        RNG->CR |= RNG_CR_RNGEN;
+#else
+        static_cast<void>(RNG->DR);
+        RNG->SR &= ~RNG_SR_SEIS;
+        RNG->CR &= ~RNG_CR_RNGEN;
+        RNG->CR |= RNG_CR_RNGEN;
+        RNG->CR |= RNG_CR_IE;
+#endif
+    }
+}
 #endif

--- a/hal_st/synchronous_stm32fxxx/SynchronousRandomDataGeneratorStm.hpp
+++ b/hal_st/synchronous_stm32fxxx/SynchronousRandomDataGeneratorStm.hpp
@@ -16,6 +16,9 @@ namespace hal
         ~SynchronousRandomDataGeneratorStm();
 
         void GenerateRandomData(infra::ByteRange result) override;
+
+    private:
+        void Reset();
     };
 }
 


### PR DESCRIPTION
The peripheral is different from former families which requires a different approach.