### PR TITLE
chore: print errors returned by HAL in tracing gatt client

### DIFF
--- a/hal_st/middlewares/ble_middleware/GattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.cpp
@@ -1,5 +1,5 @@
 #include "hal_st/middlewares/ble_middleware/GattClientSt.hpp"
-#include "ble_types.h"
+#include "ble_defs.h"
 #include "infra/event/EventDispatcherWithWeakPtr.hpp"
 #include "infra/stream/InputStream.hpp"
 #include "infra/util/Endian.hpp"

--- a/hal_st/middlewares/ble_middleware/GattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.cpp
@@ -1,4 +1,5 @@
 #include "hal_st/middlewares/ble_middleware/GattClientSt.hpp"
+#include "ble_types.h"
 #include "infra/event/EventDispatcherWithWeakPtr.hpp"
 #include "infra/stream/InputStream.hpp"
 #include "infra/util/Endian.hpp"

--- a/hal_st/middlewares/ble_middleware/GattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.hpp
@@ -1,11 +1,10 @@
 #ifndef HAL_ST_GATT_CLIENT_ST_HPP
 #define HAL_ST_GATT_CLIENT_ST_HPP
 
-#include "ble/ble.h"
+#include "ble_types.h"
 #include "hal_st/middlewares/ble_middleware/HciEventObserver.hpp"
 #include "infra/stream/ByteInputStream.hpp"
 #include "infra/util/AutoResetFunction.hpp"
-#include "infra/util/BoundedVector.hpp"
 #include "infra/util/Function.hpp"
 #include "services/ble/Gatt.hpp"
 #include "services/ble/GattClient.hpp"

--- a/hal_st/middlewares/ble_middleware/GattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GattClientSt.hpp
@@ -54,12 +54,12 @@ namespace hal
         virtual void HandleAttExchangeMtuResponse(const aci_att_exchange_mtu_resp_event_rp0& event);
 
         virtual void HandleServiceDiscovered(infra::DataInputStream& stream, bool isUuid16);
+        virtual void HandleBleStatusError(tBleStatus status);
         void HandleUuidFromDiscovery(infra::DataInputStream& stream, bool isUuid16, services::AttAttribute::Uuid& type);
 
     private:
         void HandleCharacteristicDiscovered(infra::DataInputStream& stream, bool isUuid16);
         void HandleDescriptorDiscovered(infra::DataInputStream& stream, bool isUuid16);
-        void HandleBleStatusError(tBleStatus status);
 
     protected:
         struct Atttributes

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
@@ -1,4 +1,5 @@
 #include "hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp"
+#include "ble_defs.h"
 
 namespace hal
 {

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.cpp
@@ -107,4 +107,12 @@ namespace hal
 
         GattClientSt::HandleServiceDiscovered(stream, isUuid16);
     }
+
+    void TracingGattClientSt::HandleBleStatusError(tBleStatus status)
+    {
+        if (status != BLE_STATUS_SUCCESS)
+            tracer.Trace() << "TracingGattClientSt::HandleBleStatusError, status: 0x" << infra::hex << status;
+
+        GattClientSt::HandleBleStatusError(status);
+    }
 }

--- a/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGattClientSt.hpp
@@ -28,6 +28,7 @@ namespace hal
         void HandleGattNotificationEvent(const aci_gatt_notification_event_rp0& event) override;
         void HandleGattCompleteResponse(const aci_gatt_proc_complete_event_rp0& event) override;
         void HandleServiceDiscovered(infra::DataInputStream& stream, bool isUuid16) override;
+        void HandleBleStatusError(tBleStatus status) override;
 
     private:
         services::Tracer& tracer;


### PR DESCRIPTION
This extends `TracingGattClientSt` to print any error codes which are returned by HAL calls. Success is ignored.