### PR TITLE
fix: change DMB to DSB for race condition handling

### DIFF
--- a/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
@@ -284,8 +284,8 @@ namespace hal
         // Store receive buffer size
         descriptors[receiveDescriptorAllocatedIndex].BackupAddr1 = buffer.size();
 
-        // DMB instruction to avoid race condition
-        __DMB();
+        // DSB instruction to avoid race condition
+         __DSB();
 
         // Set tail pointer to last element
         peripheralEthernet[0]->DMACRDTPR = reinterpret_cast<uint32_t>(&descriptors[receiveDescriptorAllocatedIndex]);

--- a/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
+++ b/hal_st/stm32fxxx/EthernetMacH5xxStm.cpp
@@ -284,7 +284,7 @@ namespace hal
         // Store receive buffer size
         descriptors[receiveDescriptorAllocatedIndex].BackupAddr1 = buffer.size();
 
-        // DSB instruction to avoid race condition
+        // DSB instruction to make sure that the descriptors are updated in RAM before the peripheral register is written
          __DSB();
 
         // Set tail pointer to last element


### PR DESCRIPTION
Replaced DMB instruction with DSB instruction to prevent race conditions.

This is now aligned with the STM32Fxxx EthernetMax implementation (EthernetMac.cpp) and upstream HAL driver package (see [Patch](https://github.com/STMicroelectronics/stm32h5xx-hal-driver/commit/8d26d85f7ef71f0951848aee499bd5180c14ca19)).