### PR TITLE
feat: allow specifying timer service when constructing WatchDogStm

### DIFF
--- a/hal_st/stm32fxxx/WatchDogStm.cpp
+++ b/hal_st/stm32fxxx/WatchDogStm.cpp
@@ -2,12 +2,12 @@
 
 namespace hal
 {
-    WatchDogStm::WatchDogStm(const infra::Function<void()>& onExpired, const Config& config)
+    WatchDogStm::WatchDogStm(const infra::Function<void()>& onExpired, const Config& config, uint32_t timerServiceId)
         : interruptRegistration(WWDG_IRQn, [this]()
               {
                   Interrupt();
               })
-        , feedTimerInterval(config.feedTimerInterval)
+        , feedingTimer(timerServiceId)
         , maxMissedFeeds(config.maxMissedFeeds)
         , onExpired(onExpired)
     {
@@ -16,7 +16,7 @@ namespace hal
         handle.Init.Prescaler = config.prescaler;
         handle.Init.Window = WWDG_CR_T;
         handle.Init.Counter = WWDG_CR_T;
-#if defined(STM32F7) || defined(STM32H5)
+#if defined(WWDG_EWI_ENABLE)
         handle.Init.EWIMode = WWDG_EWI_ENABLE;
 #endif
         HAL_WWDG_Init(&handle);
@@ -29,17 +29,10 @@ namespace hal
         NVIC_SetPriority(WWDG_IRQn, 0);
         WWDG->CFR |= WWDG_CFR_EWI;
 
-        UseTimerService(infra::systemTimerServiceId);
-    }
-
-    void WatchDogStm::UseTimerService(uint32_t timerServiceId)
-    {
-        Feed();
-        feedingTimer.emplace(feedTimerInterval, [this]()
+        feedingTimer.Start(config.feedTimerInterval, [this]()
             {
                 Feed();
-            },
-            timerServiceId);
+            });
     }
 
     void WatchDogStm::WatchDogRefresh()

--- a/hal_st/stm32fxxx/WatchDogStm.cpp
+++ b/hal_st/stm32fxxx/WatchDogStm.cpp
@@ -2,12 +2,12 @@
 
 namespace hal
 {
-    WatchDogStm::WatchDogStm(const infra::Function<void()>& onExpired, const Config& config, uint32_t timerServiceId)
+    WatchDogStm::WatchDogStm(const infra::Function<void()>& onExpired, const Config& config)
         : interruptRegistration(WWDG_IRQn, [this]()
               {
                   Interrupt();
               })
-        , feedingTimer(timerServiceId)
+        , feedingTimer(config.timerServiceId)
         , maxMissedFeeds(config.maxMissedFeeds)
         , onExpired(onExpired)
     {

--- a/hal_st/stm32fxxx/WatchDogStm.cpp
+++ b/hal_st/stm32fxxx/WatchDogStm.cpp
@@ -3,19 +3,20 @@
 namespace hal
 {
     WatchDogStm::WatchDogStm(const infra::Function<void()>& onExpired, const Config& config)
-        : maxMissedFeeds(config.maxMissedFeeds)
-        , onExpired(onExpired)
-        , interruptRegistration(WWDG_IRQn, [this]()
+        : interruptRegistration(WWDG_IRQn, [this]()
               {
                   Interrupt();
               })
+        , feedTimerInterval(config.feedTimerInterval)
+        , maxMissedFeeds(config.maxMissedFeeds)
+        , onExpired(onExpired)
     {
         __WWDG_CLK_ENABLE();
         handle.Instance = WWDG;
         handle.Init.Prescaler = config.prescaler;
         handle.Init.Window = WWDG_CR_T;
         handle.Init.Counter = WWDG_CR_T;
-#ifdef STM32F7
+#if defined(STM32F7) || defined(STM32H5)
         handle.Init.EWIMode = WWDG_EWI_ENABLE;
 #endif
         HAL_WWDG_Init(&handle);
@@ -28,10 +29,17 @@ namespace hal
         NVIC_SetPriority(WWDG_IRQn, 0);
         WWDG->CFR |= WWDG_CFR_EWI;
 
-        feedingTimer.Start(config.feedTimerInterval, [this]()
+        UseTimerService(infra::systemTimerServiceId);
+    }
+
+    void WatchDogStm::UseTimerService(uint32_t timerServiceId)
+    {
+        Feed();
+        feedingTimer.emplace(feedTimerInterval, [this]()
             {
                 Feed();
-            });
+            },
+            timerServiceId);
     }
 
     void WatchDogStm::WatchDogRefresh()

--- a/hal_st/stm32fxxx/WatchDogStm.hpp
+++ b/hal_st/stm32fxxx/WatchDogStm.hpp
@@ -5,7 +5,6 @@
 #include "hal_st/cortex/InterruptCortex.hpp"
 #include "infra/timer/Timer.hpp"
 #include <atomic>
-#include <optional>
 
 namespace hal
 {
@@ -30,18 +29,16 @@ namespace hal
     public:
         using Config = detail::WatchDogStmConfig;
 
-        explicit WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config());
+        WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config(), uint32_t timerServiceId = infra::systemTimerServiceId);
 
         void WatchDogRefresh();
-        void UseTimerService(uint32_t timerServiceId);
 
     private:
         void Interrupt();
         void Feed();
 
         ImmediateInterruptHandler interruptRegistration;
-        std::optional<infra::TimerRepeating> feedingTimer;
-        infra::Duration feedTimerInterval;
+        infra::TimerRepeating feedingTimer;
         WWDG_HandleTypeDef handle;
         std::atomic<uint32_t> missedFeedCount{ 0 };
         const uint32_t maxMissedFeeds{ 0 };

--- a/hal_st/stm32fxxx/WatchDogStm.hpp
+++ b/hal_st/stm32fxxx/WatchDogStm.hpp
@@ -5,6 +5,7 @@
 #include "hal_st/cortex/InterruptCortex.hpp"
 #include "infra/timer/Timer.hpp"
 #include <atomic>
+#include <optional>
 
 namespace hal
 {
@@ -29,16 +30,18 @@ namespace hal
     public:
         using Config = detail::WatchDogStmConfig;
 
-        WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config());
+        explicit WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config());
 
         void WatchDogRefresh();
+        void UseTimerService(uint32_t timerServiceId);
 
     private:
         void Interrupt();
         void Feed();
 
         ImmediateInterruptHandler interruptRegistration;
-        infra::TimerRepeating feedingTimer;
+        std::optional<infra::TimerRepeating> feedingTimer;
+        infra::Duration feedTimerInterval;
         WWDG_HandleTypeDef handle;
         std::atomic<uint32_t> missedFeedCount{ 0 };
         const uint32_t maxMissedFeeds{ 0 };

--- a/hal_st/stm32fxxx/WatchDogStm.hpp
+++ b/hal_st/stm32fxxx/WatchDogStm.hpp
@@ -21,6 +21,7 @@ namespace hal
             uint32_t prescaler{ WWDG_PRESCALER_8 };
             infra::Duration feedTimerInterval{ std::chrono::milliseconds(25) };
             uint32_t maxMissedFeeds{ 41 };
+            uint32_t timerServiceId = infra::systemTimerServiceId;
         };
     }
 
@@ -29,7 +30,7 @@ namespace hal
     public:
         using Config = detail::WatchDogStmConfig;
 
-        WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config(), uint32_t timerServiceId = infra::systemTimerServiceId);
+        WatchDogStm(const infra::Function<void()>& onExpired, const Config& config = Config());
 
         void WatchDogRefresh();
 

--- a/hal_st/stm32fxxx/WatchDogStm.hpp
+++ b/hal_st/stm32fxxx/WatchDogStm.hpp
@@ -21,7 +21,7 @@ namespace hal
             uint32_t prescaler{ WWDG_PRESCALER_8 };
             infra::Duration feedTimerInterval{ std::chrono::milliseconds(25) };
             uint32_t maxMissedFeeds{ 41 };
-            uint32_t timerServiceId = infra::systemTimerServiceId;
+            uint32_t timerServiceId{ infra::systemTimerServiceId };
         };
     }
 


### PR DESCRIPTION
- Fix initialization order in WatchDogStm constructor to fit the hpp.
- Set EWIMode on other targets than just STM32F7 if specified.
- Allow for the timer service ID to optionally be passed in the constructor, defaulting to the system timer service. This is relevant in power fail scenarios where the system timer service won't be able to feed the watchdog.