### PR TITLE
fix: erase for internal flash on WBA

### DIFF
--- a/hal_st/stm32fxxx/FlashInternalStm.cpp
+++ b/hal_st/stm32fxxx/FlashInternalStm.cpp
@@ -19,6 +19,16 @@ namespace
     }
 #endif
 
+#if defined(STM32WBA) && defined(FLASH_DBANK_SUPPORT)
+    uint32_t GetPage(const uint8_t* memoryBegin)
+    {
+        auto address = reinterpret_cast<uint32_t>(memoryBegin);
+        if (address < (FLASH_BASE + FLASH_BANK_SIZE))
+            return (address - FLASH_BASE) / FLASH_PAGE_SIZE;
+        return (address - (FLASH_BASE + FLASH_BANK_SIZE)) / FLASH_PAGE_SIZE;
+    }
+#endif
+
     struct uint128_t
     {
 #ifdef __ARM_BIG_ENDIAN
@@ -93,8 +103,10 @@ namespace hal
         eraseInitStruct.TypeErase = FLASH_TYPEERASE_PAGES;
         eraseInitStruct.Page = beginIndex;
         eraseInitStruct.NbPages = endIndex - beginIndex;
-#if defined(STM32H5) || defined(STM32WBA) && defined(FLASH_DBANK_SUPPORT)
-        eraseInitStruct.Banks = GetBank(flashMemory.begin());
+#if defined(STM32WBA) && defined(FLASH_DBANK_SUPPORT)
+        const auto* beginAddress = flashMemory.begin() + beginIndex * FLASH_PAGE_SIZE;
+        eraseInitStruct.Banks = GetBank(beginAddress);
+        eraseInitStruct.Page = GetPage(beginAddress);
 #endif
 
         auto result = HAL_FLASHEx_Erase(&eraseInitStruct, &pageError);


### PR DESCRIPTION
WBA has the page mapping per bank and not a single mapping as the others ST families currently supported. 
For this reason, during an internal flash erase, it's necessary to identify the correct page on the used bank accordingly. 