### PR TITLE
fix: give a peripheral enough time to complete secure connections pairing

### DIFF
--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -14,7 +14,7 @@ namespace hal
         6, // 7.5 ms
         6, // 7.5 ms
         0,
-        50, // 500 ms
+        500, // 5 s
     };
 
     // Connection Interval parameters


### PR DESCRIPTION
## Problem

`GapCentralSt` hard-codes a 500 ms supervision timeout for the connection parameters it requests after connecting:

```cpp
const services::GapConnectionParameters GapCentralSt::connectionUpdateParameters{
    6, 6, 0, 50, // 500 ms
};
```

That is too short for a peripheral without an ECC accelerator. LE Secure Connections pairing requires two P-256 scalar multiplications, and on a CC2340R53 (Cortex-M0+ at 48 MHz, TI SimpleLink LP F3 SDK, `ECDHLPF3SW.c` software implementation, `ecdhMode = ECDH_RETURN_BEHAVIOR_BLOCKING`) each one blocks the link layer for roughly 650 ms. TI's own `ll_ecc.c` warns that the routine "will tie up the LL for about 160 ms".

Measured on hardware, such a peripheral needs about 1350 ms between `PAIRING_STARTED` and the numeric comparison callback, so the link is supervised out long before pairing can finish. LE legacy pairing is unaffected because it only uses AES-128, which is why the problem only appears once Secure Connections is required.

## Change

Raise the requested supervision timeout to 5 s. Nothing else is touched, and the connection interval stays at 7.5 ms.

## Caveat for reviewers

A longer supervision timeout also means a central takes longer to notice a peripheral that disappears. In the connectivity-nodes integration suite this makes the reset-based scenarios (`SecurityPeripheral01`, `FWD08`) wait longer for the disconnect than their current windows allow. The two requirements are in tension — Secure Connections on a software-ECDH peripheral needs more than ~1.4 s, while those scenarios expect a disconnect inside about 2 s — so the exact value is worth discussing. Making it configurable per product rather than a single constant may be the better long-term answer.

Also note `HandleL2capConnectionUpdateRequestEvent` still rejects peripheral-initiated parameter updates unconditionally, so a peripheral cannot negotiate this for itself.
