### PR TITLE
feat: take address and connection parameters in GapCentralSt::Connect

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        53776aa127e1e6695b45b31d3a32c9d2aceb2238 # unreleased
+        GIT_TAG        40b279aa668e4eaa5bf24459aeabeb99dc26100a # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        40b279aa668e4eaa5bf24459aeabeb99dc26100a  # unreleased
+        GIT_TAG        f9c40c3a3b5a1332e148536e96f76339b9a2f3da  # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        13b90dc5534d821b0667e003f317cc8754478f83 # unreleased
+        GIT_TAG        260b74688d99a972d40bb463dd294e844efcfb8a # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        40b279aa668e4eaa5bf24459aeabeb99dc26100a # unreleased
+        GIT_TAG        13b90dc5534d821b0667e003f317cc8754478f83 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -54,8 +54,8 @@ namespace hal
 
         aci_gap_create_connection(
             leScanInterval, leScanWindow, peerAddress, address.address.data(), ownAddressType,
-            connectionUpdateParameters.minConnIntMultiplier, connectionUpdateParameters.maxConnIntMultiplier,
-            connectionUpdateParameters.slaveLatency, connectionUpdateParameters.supervisorTimeoutMs,
+            connectionUpdateParameters.minConnectionIntervalMultiplier, connectionUpdateParameters.maxConnectionIntervalMultiplier,
+            connectionUpdateParameters.peripheralLatency, connectionUpdateParameters.supervisionTimeoutMultiplier,
             minConnectionEventLength, maxConnectionEventLength);
 
         infra::Subject<services::GapCentralObserver>::NotifyObservers([](auto& observer)
@@ -197,8 +197,8 @@ namespace hal
         infra::EventDispatcherWithWeakPtr::Instance().Schedule([this, identifier]()
             {
                 auto status = aci_l2cap_connection_parameter_update_resp(
-                    connectionContext.connectionHandle, connectionUpdateParameters.minConnIntMultiplier, connectionUpdateParameters.maxConnIntMultiplier,
-                    connectionUpdateParameters.slaveLatency, connectionUpdateParameters.supervisorTimeoutMs,
+                    connectionContext.connectionHandle, connectionUpdateParameters.minConnectionIntervalMultiplier, connectionUpdateParameters.maxConnectionIntervalMultiplier,
+                    connectionUpdateParameters.peripheralLatency, connectionUpdateParameters.supervisionTimeoutMultiplier,
                     minConnectionEventLength, maxConnectionEventLength, identifier, rejectParameters);
                 assert(status == BLE_STATUS_SUCCESS);
             });

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -10,13 +10,6 @@
 
 namespace hal
 {
-    const services::GapConnectionParameters GapCentralSt::connectionUpdateParameters{
-        6, // 7.5 ms
-        6, // 7.5 ms
-        0,
-        50, // 500 ms
-    };
-
     // Connection Interval parameters
     const uint16_t minConnectionEventLength = 0;
     const uint16_t maxConnectionEventLength = 0x280; // 400 ms
@@ -53,12 +46,14 @@ namespace hal
         Initialize(configuration);
     }
 
-    void GapCentralSt::Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout)
+    void GapCentralSt::Connect(services::GapAddress address, const services::GapConnectionParameters& connectionParameters, infra::Duration initiatingTimeout)
     {
-        auto peerAddress = addressType == services::GapDeviceAddressType::publicAddress ? GAP_PUBLIC_ADDR : GAP_STATIC_RANDOM_ADDR;
+        connectionUpdateParameters = connectionParameters;
+
+        auto peerAddress = address.type == services::GapDeviceAddressType::publicAddress ? GAP_PUBLIC_ADDR : GAP_STATIC_RANDOM_ADDR;
 
         aci_gap_create_connection(
-            leScanInterval, leScanWindow, peerAddress, macAddress.data(), ownAddressType,
+            leScanInterval, leScanWindow, peerAddress, address.address.data(), ownAddressType,
             connectionUpdateParameters.minConnIntMultiplier, connectionUpdateParameters.maxConnIntMultiplier,
             connectionUpdateParameters.slaveLatency, connectionUpdateParameters.supervisorTimeoutMs,
             minConnectionEventLength, maxConnectionEventLength);

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -16,7 +16,7 @@ namespace hal
         GapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration);
 
         // Implementation of services::GapCentral
-        void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;
+        void Connect(services::GapAddress address, const services::GapConnectionParameters& connectionParameters, infra::Duration initiatingTimeout) override;
         void Standby() override;
         void SetIdentityAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType) override;
         void StartDeviceDiscovery() override;
@@ -54,7 +54,8 @@ namespace hal
         void Initialize(const Configuration& configuration);
 
     private:
-        static const services::GapConnectionParameters connectionUpdateParameters;
+        // Retained from Connect so a parameter update request can be answered with the same values.
+        services::GapConnectionParameters connectionUpdateParameters{};
 
         // Create connection parameters
         const uint16_t leScanInterval = 0x320;

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -54,7 +54,6 @@ namespace hal
         void Initialize(const Configuration& configuration);
 
     private:
-        // Retained from Connect so a parameter update request can be answered with the same values.
         services::GapConnectionParameters connectionUpdateParameters{};
 
         // Create connection parameters

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -126,8 +126,8 @@ namespace hal
     void GapPeripheralSt::SetConnectionParameters(const services::GapConnectionParameters& connParam)
     {
         aci_l2cap_connection_parameter_update_req(connectionContext.connectionHandle,
-            connParam.minConnIntMultiplier, connParam.maxConnIntMultiplier,
-            connParam.slaveLatency, connParam.supervisorTimeoutMs);
+            connParam.minConnectionIntervalMultiplier, connParam.maxConnectionIntervalMultiplier,
+            connParam.peripheralLatency, connParam.supervisionTimeoutMultiplier);
     }
 
     void GapPeripheralSt::AllowPairing(bool allow)

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -7,15 +7,23 @@ namespace hal
         , tracer(tracer)
     {}
 
-    void TracingGapCentralSt::Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout)
+    void TracingGapCentralSt::Connect(services::GapAddress address, const services::GapConnectionParameters& connectionParameters, infra::Duration initiatingTimeout)
     {
         tracer.Trace() << "TracingGapCentralSt::Connect, MAC address: "
-                       << infra::AsMacAddress(macAddress)
+                       << infra::AsMacAddress(address.address)
                        << ", type: "
-                       << addressType
+                       << address.type
+                       << ", connection interval: "
+                       << connectionParameters.minConnIntMultiplier
+                       << "-"
+                       << connectionParameters.maxConnIntMultiplier
+                       << ", peripheral latency: "
+                       << connectionParameters.slaveLatency
+                       << ", supervision timeout: "
+                       << connectionParameters.supervisorTimeoutMs
                        << ", initiating timeout (ms): "
                        << std::chrono::duration_cast<std::chrono::milliseconds>(initiatingTimeout).count();
-        GapCentralSt::Connect(macAddress, addressType, initiatingTimeout);
+        GapCentralSt::Connect(address, connectionParameters, initiatingTimeout);
     }
 
     void TracingGapCentralSt::Standby()

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -14,13 +14,13 @@ namespace hal
                        << ", type: "
                        << address.type
                        << ", connection interval: "
-                       << connectionParameters.minConnIntMultiplier
+                       << connectionParameters.minConnectionIntervalMultiplier
                        << "-"
-                       << connectionParameters.maxConnIntMultiplier
+                       << connectionParameters.maxConnectionIntervalMultiplier
                        << ", peripheral latency: "
-                       << connectionParameters.slaveLatency
+                       << connectionParameters.peripheralLatency
                        << ", supervision timeout: "
-                       << connectionParameters.supervisorTimeoutMs
+                       << connectionParameters.supervisionTimeoutMultiplier
                        << ", initiating timeout (ms): "
                        << std::chrono::duration_cast<std::chrono::milliseconds>(initiatingTimeout).count();
         GapCentralSt::Connect(address, connectionParameters, initiatingTimeout);

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
@@ -13,7 +13,7 @@ namespace hal
         TracingGapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration, services::Tracer& tracer);
 
         // Implementation of services::GapCentral
-        void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;
+        void Connect(services::GapAddress address, const services::GapConnectionParameters& connectionParameters, infra::Duration initiatingTimeout) override;
         void Standby() override;
         void SetIdentityAddress(hal::MacAddress macAddress, services::GapDeviceAddressType addressType) override;
         void StartDeviceDiscovery() override;


### PR DESCRIPTION
Follows the GapCentral interface change in amp-embedded-infra-lib. The connection parameters used for aci_gap_create_connection were a hard-coded constant, so a central always opened connections with a 500 ms supervision timeout no matter what the peer needed. A peripheral without a hardware ECC engine blocks for well over a second computing LE Secure Connections key material and was supervised out before pairing could finish.

The parameters now come from the caller and are retained so that a peripheral initiated parameter update request is answered with the same values.

BREAKING CHANGE: GapCentralSt::Connect and TracingGapCentralSt::Connect take a services::GapAddress and services::GapConnectionParameters instead of a MAC address and address type.