### PR TITLE
refactor(ble): improve bond storage mechanisms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        ac578ae5b2c24aeb26d4806a5eed13579ba5968c # unreleased
+        GIT_TAG        d04d5d18d74f3eb7915d35398b80b9f61f789b0a # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        bf579374151c3605eaf6c25fa26426eddb3f15a6 # unreleased
+        GIT_TAG        5a05c470a68dbeb44a3c52ae2194b4a85b4bb0d3 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        d04d5d18d74f3eb7915d35398b80b9f61f789b0a # unreleased
+        GIT_TAG        bf579374151c3605eaf6c25fa26426eddb3f15a6 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        1689a8e2a4e1d8ede8c69862f3fe5b02d3094964 # unreleased
+        GIT_TAG        df18d62971b3041a27d0f6fe9e0724e0bd22e30b # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        5a05c470a68dbeb44a3c52ae2194b4a85b4bb0d3 # unreleased
+        GIT_TAG        1689a8e2a4e1d8ede8c69862f3fe5b02d3094964 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if (HALST_STANDALONE)
     FetchContent_Declare(
         emil
         GIT_REPOSITORY https://github.com/philips-software/amp-embedded-infra-lib.git
-        GIT_TAG        df18d62971b3041a27d0f6fe9e0724e0bd22e30b # unreleased
+        GIT_TAG        3b789992659cf4fac129e0657f5b2421871a5b26 # unreleased
     )
     FetchContent_MakeAvailable(emil)
 

--- a/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.cpp
@@ -1,4 +1,4 @@
-#include "hal_st/middlewares/ble_middleware/BondStorageSt.hpp"
+#include "hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.hpp"
 #include "infra/util/LogAndAbort.hpp"
 #include "services/ble/Gap.hpp"
 
@@ -34,14 +34,14 @@ namespace
 
 namespace hal
 {
-    BondStorageSt::BondStorageSt(uint32_t maxNumberOfBonds)
+    AuthoritativeBondStorageSt::AuthoritativeBondStorageSt(uint32_t maxNumberOfBonds)
         : maxNumberOfBonds(maxNumberOfBonds)
     {}
 
-    void BondStorageSt::BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager)
+    void AuthoritativeBondStorageSt::BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager)
     {}
 
-    void BondStorageSt::RemoveBond(const services::GapAddress& address)
+    void AuthoritativeBondStorageSt::RemoveBond(const services::GapAddress& address)
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
@@ -52,7 +52,7 @@ namespace hal
                 aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
     }
 
-    void BondStorageSt::RemoveAllBonds()
+    void AuthoritativeBondStorageSt::RemoveAllBonds()
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
@@ -62,7 +62,7 @@ namespace hal
             aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
     }
 
-    void BondStorageSt::RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress)
+    void AuthoritativeBondStorageSt::RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress)
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
@@ -71,10 +71,9 @@ namespace hal
         for (auto i = 0; i != numberOfBonds; ++i)
             if (onAddress(ToGapAddress(storage[i])))
                 aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
-
     }
 
-    uint32_t BondStorageSt::GetNumberOfBonds() const
+    uint32_t AuthoritativeBondStorageSt::GetNumberOfBonds() const
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
@@ -83,12 +82,12 @@ namespace hal
         return numberOfBonds;
     }
 
-    uint32_t BondStorageSt::GetMaxNumberOfBonds() const
+    uint32_t AuthoritativeBondStorageSt::GetMaxNumberOfBonds() const
     {
         return maxNumberOfBonds;
     }
 
-    bool BondStorageSt::IsBondStored(const services::GapAddress& address) const
+    bool AuthoritativeBondStorageSt::IsBondStored(const services::GapAddress& address) const
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
@@ -101,7 +100,7 @@ namespace hal
         return false;
     }
 
-    void BondStorageSt::IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond)
+    void AuthoritativeBondStorageSt::IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond)
     {
         uint8_t numberOfBonds = 0;
         BondStorageInternal storage;

--- a/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.hpp
+++ b/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.hpp
@@ -16,7 +16,7 @@ namespace hal
     public:
         explicit AuthoritativeBondStorageSt(uint32_t maxNumberOfBonds);
 
-        // Implementation of BondStorage
+        // Implementation of EnrichedBondStorage
         void BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager) override;
         void RemoveBond(const services::GapAddress& address) override;
         void RemoveAllBonds() override;

--- a/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.hpp
+++ b/hal_st/middlewares/ble_middleware/AuthoritativeBondStorageSt.hpp
@@ -10,11 +10,11 @@ extern "C"
 
 namespace hal
 {
-    class BondStorageSt
+    class AuthoritativeBondStorageSt
         : public services::AuthoritativeBondStorage
     {
     public:
-        explicit BondStorageSt(uint32_t maxNumberOfBonds);
+        explicit AuthoritativeBondStorageSt(uint32_t maxNumberOfBonds);
 
         // Implementation of BondStorage
         void BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager) override;

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -80,6 +80,15 @@ namespace hal
         // TODO: REmove this function?
     }
 
+    uint32_t BondStorageSt::GetNumberOfBonds() const
+    {
+        uint8_t numberOfBonds;
+        BondStorageInternal storage;
+        aci_gap_get_bonded_devices(&numberOfBonds, storage);
+
+        return numberOfBonds;
+    }
+
     uint32_t BondStorageSt::GetMaxNumberOfBonds() const
     {
         return maxNumberOfBonds;

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -1,4 +1,49 @@
 #include "hal_st/middlewares/ble_middleware/BondStorageSt.hpp"
+#include "infra/util/LogAndAbort.hpp"
+#include "services/ble/Gap.hpp"
+
+namespace
+{
+    bool ToHalAddressType(services::GapDeviceAddressType addressType)
+    {
+        switch (addressType)
+        {
+            case services::GapDeviceAddressType::publicAddress:
+                return 0x00;
+            case services::GapDeviceAddressType::randomAddress:
+                return 0x01;
+            default:
+                LOG_AND_ABORT_ENUM(addressType);
+        }
+    }
+
+    services::GapDeviceAddressType ToGapAddressType(uint8_t addressType)
+    {
+        switch (addressType)
+        {
+            case 0x00:
+                return services::GapDeviceAddressType::publicAddress;
+            case 0x01:
+                return services::GapDeviceAddressType::randomAddress;
+            default:
+                LOG_AND_ABORT_ENUM(addressType);
+        }
+    }
+
+    bool AddressMatchesBond(const services::GapAddress& address, Bonded_Device_Entry_t& bondEntry)
+    {
+        return address.type == ToHalAddressType(bondEntry.Address_Type) &&
+               infra::ContentsEqual(infra::MakeRange(address.address), infra::MakeRange(bondEntry.Address));
+    }
+
+    services::GapAddress ToGapAddress(const Bonded_Device_Entry_t& bondEntry)
+    {
+        services::GapAddress address;
+        std::copy(bondEntry.Address, bondEntry.Address + sizeof(bondEntry.Address), address.address.begin());
+        address.type = ToGapAddressType(bondEntry.Address_Type);
+        return address;
+    }
+}
 
 namespace hal
 {
@@ -9,19 +54,14 @@ namespace hal
     void BondStorageSt::BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager)
     {}
 
-    void BondStorageSt::UpdateBondedDevice(hal::MacAddress address)
-    {
-        // ST middleware handles updating of bonds list internally, so we don't have anything to update here.
-    }
-
-    void BondStorageSt::RemoveBond(hal::MacAddress address)
+    void BondStorageSt::RemoveBond(const services::GapAddress& address)
     {
         uint8_t numberOfBonds;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
         for (auto i = 0; i != numberOfBonds; ++i)
-            if (infra::ContentsEqual(infra::MakeRange(storage[i].Address), infra::MakeRange(address)))
+            if (AddressMatchesBond(address, storage[i]))
                 aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
     }
 
@@ -36,37 +76,35 @@ namespace hal
     }
 
     void BondStorageSt::RemoveBondIf(const infra::Function<bool(hal::MacAddress)>& onAddress)
-    {}
+    {
+        // TODO: REmove this function?
+    }
 
     uint32_t BondStorageSt::GetMaxNumberOfBonds() const
     {
         return maxNumberOfBonds;
     }
 
-    bool BondStorageSt::IsBondStored(hal::MacAddress address) const
+    bool BondStorageSt::IsBondStored(const services::GapAddress& address) const
     {
         uint8_t numberOfBonds;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
         for (auto i = 0; i != numberOfBonds; ++i)
-            if (infra::ContentsEqual(infra::MakeRange(storage[i].Address), infra::MakeRange(address)))
+            if (AddressMatchesBond(address, storage[i]))
                 return true;
 
         return false;
     }
 
-    void BondStorageSt::IterateBondedDevices(const infra::Function<void(hal::MacAddress)>& onAddress)
+    void BondStorageSt::IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond)
     {
         uint8_t numberOfBonds;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
         for (auto i = 0; i != numberOfBonds; ++i)
-        {
-            hal::MacAddress address;
-            infra::Copy(infra::MakeRange(storage[i].Address), infra::MakeRange(address));
-            onAddress(address);
-        }
+            onBond(ToGapAddress(storage[i]));
     }
 }

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -32,8 +32,8 @@ namespace
 
     bool AddressMatchesBond(const services::GapAddress& address, const Bonded_Device_Entry_t& bondEntry)
     {
-        return address.type == ToGapAddressType(bondEntry.Address_Type) &&
-               infra::ContentsEqual(infra::MakeRange(address.address), infra::MakeRange(bondEntry.Address));
+        // Note: specifically not checking the address type, since it's not stored in shadow storage currently.
+        return infra::ContentsEqual(infra::MakeRange(address.address), infra::MakeRange(bondEntry.Address));
     }
 
     services::GapAddress ToGapAddress(const Bonded_Device_Entry_t& bondEntry)

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -70,7 +70,7 @@ namespace hal
     uint32_t BondStorageSt::GetNumberOfBonds() const
     {
         uint8_t numberOfBonds = 0;
-        BondStorageInternal storage = 0;
+        BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
         return numberOfBonds;

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -30,9 +30,9 @@ namespace
         }
     }
 
-    bool AddressMatchesBond(const services::GapAddress& address, Bonded_Device_Entry_t& bondEntry)
+    bool AddressMatchesBond(const services::GapAddress& address, const Bonded_Device_Entry_t& bondEntry)
     {
-        return address.type == ToHalAddressType(bondEntry.Address_Type) &&
+        return address.type == ToGapAddressType(bondEntry.Address_Type) &&
                infra::ContentsEqual(infra::MakeRange(address.address), infra::MakeRange(bondEntry.Address));
     }
 
@@ -75,7 +75,7 @@ namespace hal
             aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
     }
 
-    void BondStorageSt::RemoveBondIf(const infra::Function<bool(hal::MacAddress)>& onAddress)
+    void BondStorageSt::RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress)
     {
         // TODO: REmove this function?
     }

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -4,19 +4,6 @@
 
 namespace
 {
-    bool ToHalAddressType(services::GapDeviceAddressType addressType)
-    {
-        switch (addressType)
-        {
-            case services::GapDeviceAddressType::publicAddress:
-                return 0x00;
-            case services::GapDeviceAddressType::randomAddress:
-                return 0x01;
-            default:
-                LOG_AND_ABORT_ENUM(addressType);
-        }
-    }
-
     services::GapDeviceAddressType ToGapAddressType(uint8_t addressType)
     {
         switch (addressType)
@@ -56,7 +43,7 @@ namespace hal
 
     void BondStorageSt::RemoveBond(const services::GapAddress& address)
     {
-        uint8_t numberOfBonds;
+        uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
@@ -67,7 +54,7 @@ namespace hal
 
     void BondStorageSt::RemoveAllBonds()
     {
-        uint8_t numberOfBonds;
+        uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
@@ -77,13 +64,13 @@ namespace hal
 
     void BondStorageSt::RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress)
     {
-        // TODO: REmove this function?
+        LOG_AND_ABORT_NOT_IMPLEMENTED();
     }
 
     uint32_t BondStorageSt::GetNumberOfBonds() const
     {
-        uint8_t numberOfBonds;
-        BondStorageInternal storage;
+        uint8_t numberOfBonds = 0;
+        BondStorageInternal storage = 0;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
         return numberOfBonds;
@@ -96,7 +83,7 @@ namespace hal
 
     bool BondStorageSt::IsBondStored(const services::GapAddress& address) const
     {
-        uint8_t numberOfBonds;
+        uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 
@@ -109,7 +96,7 @@ namespace hal
 
     void BondStorageSt::IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond)
     {
-        uint8_t numberOfBonds;
+        uint8_t numberOfBonds = 0;
         BondStorageInternal storage;
         aci_gap_get_bonded_devices(&numberOfBonds, storage);
 

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.cpp
@@ -64,7 +64,14 @@ namespace hal
 
     void BondStorageSt::RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress)
     {
-        LOG_AND_ABORT_NOT_IMPLEMENTED();
+        uint8_t numberOfBonds = 0;
+        BondStorageInternal storage;
+        aci_gap_get_bonded_devices(&numberOfBonds, storage);
+
+        for (auto i = 0; i != numberOfBonds; ++i)
+            if (onAddress(ToGapAddress(storage[i])))
+                aci_gap_remove_bonded_device(storage[i].Address_Type, storage[i].Address);
+
     }
 
     uint32_t BondStorageSt::GetNumberOfBonds() const
@@ -102,5 +109,9 @@ namespace hal
 
         for (auto i = 0; i != numberOfBonds; ++i)
             onBond(ToGapAddress(storage[i]));
+
+        uint8_t numberOfBondsAfter = 0;
+        aci_gap_get_bonded_devices(&numberOfBondsAfter, storage);
+        really_assert(numberOfBondsAfter == numberOfBonds); // This iteration is not CRUD safe
     }
 }

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
@@ -21,6 +21,7 @@ namespace hal
         void RemoveBond(const services::GapAddress& address) override;
         void RemoveAllBonds() override;
         void RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress) override;
+        uint32_t GetNumberOfBonds() const override;
         uint32_t GetMaxNumberOfBonds() const override;
         bool IsBondStored(const services::GapAddress& address) const override;
         void IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond) override;

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
@@ -11,20 +11,19 @@ extern "C"
 namespace hal
 {
     class BondStorageSt
-        : public services::BondStorage
+        : public services::BondStorageAbsolute
     {
     public:
         explicit BondStorageSt(uint32_t maxNumberOfBonds);
 
         // Implementation of BondStorage
         void BondStorageSynchronizerCreated(services::BondStorageSynchronizer& manager) override;
-        void UpdateBondedDevice(hal::MacAddress address) override;
-        void RemoveBond(hal::MacAddress address) override;
+        void RemoveBond(const services::GapAddress& address) override;
         void RemoveAllBonds() override;
-        void RemoveBondIf(const infra::Function<bool(hal::MacAddress)>& onAddress) override;
+        void RemoveBondIf(const infra::Function<bool(const services::GapAddress&)>& onAddress) override;
         uint32_t GetMaxNumberOfBonds() const override;
-        bool IsBondStored(hal::MacAddress address) const override;
-        void IterateBondedDevices(const infra::Function<void(hal::MacAddress)>& onAddress) override;
+        bool IsBondStored(const services::GapAddress& address) const override;
+        void IterateBondedDevices(const infra::Function<void(const services::GapAddress&)>& onBond) override;
 
     private:
         using BondStorageInternal = Bonded_Device_Entry_t[((BLE_EVT_MAX_PARAM_LEN - 3) - 2) / sizeof(Bonded_Device_Entry_t)];

--- a/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
+++ b/hal_st/middlewares/ble_middleware/BondStorageSt.hpp
@@ -11,7 +11,7 @@ extern "C"
 namespace hal
 {
     class BondStorageSt
-        : public services::BondStorageAbsolute
+        : public services::AuthoritativeBondStorage
     {
     public:
         explicit BondStorageSt(uint32_t maxNumberOfBonds);

--- a/hal_st/middlewares/ble_middleware/CMakeLists.txt
+++ b/hal_st/middlewares/ble_middleware/CMakeLists.txt
@@ -20,8 +20,8 @@ target_link_libraries(hal_st.ble_middleware PUBLIC
 target_sources(hal_st.ble_middleware PRIVATE
     BleDtmSt.cpp
     BleDtmSt.hpp
-    BondStorageSt.cpp
-    BondStorageSt.hpp
+    AuthoritativeBondStorageSt.cpp
+    AuthoritativeBondStorageSt.hpp
     GapCentralSt.cpp
     GapCentralSt.hpp
     GapPeripheralSt.cpp

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.cpp
@@ -45,8 +45,8 @@ namespace hal
         }
     }
 
-    GapCentralSt::GapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration)
-        : GapSt(hciEventSource, bondStorageSynchronizer, configuration)
+    GapCentralSt::GapCentralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration)
+        : GapSt(hciEventSource, configuration)
         , gapService(configuration.gapService)
         , security(configuration.security)
     {

--- a/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapCentralSt.hpp
@@ -13,7 +13,7 @@ namespace hal
         , public GapSt
     {
     public:
-        GapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration);
+        GapCentralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration);
 
         // Implementation of services::GapCentral
         void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.cpp
@@ -12,8 +12,8 @@ namespace
 
 namespace hal
 {
-    GapPeripheralSt::GapPeripheralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration)
-        : GapSt(hciEventSource, bondStorageSynchronizer, configuration)
+    GapPeripheralSt::GapPeripheralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration)
+        : GapSt(hciEventSource, configuration)
     {
         Initialize(configuration);
     }

--- a/hal_st/middlewares/ble_middleware/GapPeripheralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapPeripheralSt.hpp
@@ -11,7 +11,7 @@ namespace hal
         , public GapSt
     {
     public:
-        GapPeripheralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration);
+        GapPeripheralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration);
 
         // Implementation of GapPeripheral
         services::GapAddress GetAddress() const override;

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -50,11 +50,11 @@ namespace hal
         }
     }
 
-    GapSt::GapSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration)
+    GapSt::GapSt(hal::HciEventSource& hciEventSource, const Configuration& configuration)
         : HciEventSink(hciEventSource)
         , ownAddressType(configuration.privacy ? GAP_RESOLVABLE_PRIVATE_ADDR : GAP_PUBLIC_ADDR)
         , securityLevel(configuration.security.securityLevel)
-        , bondStorageSynchronizer(bondStorageSynchronizer)
+        , bondStorageInteractor(configuration.bondStorageInteractor)
         , rootKeys(configuration.rootKeys)
         , publicAddress(configuration.address)
         , txPowerLevel(configuration.txPowerLevel)
@@ -94,7 +94,7 @@ namespace hal
 
     void GapSt::RemoveAllBonds()
     {
-        bondStorageSynchronizer.RemoveAllBonds();
+        bondStorageInteractor.RemoveAllBonds();
         UpdateNrBonds();
     }
 
@@ -110,7 +110,7 @@ namespace hal
 
     std::size_t GapSt::GetMaxNumberOfBonds() const
     {
-        return bondStorageSynchronizer.GetMaxNumberOfBonds();
+        return bondStorageInteractor.GetMaxNumberOfBonds();
     }
 
     std::size_t GapSt::GetNumberOfBonds() const
@@ -436,7 +436,7 @@ namespace hal
 
         hal::MacAddress address = connectionContext.peerAddress;
         aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), address.data());
-        bondStorageSynchronizer.UpdateBondedDevice(address);
+        // bondStorageInteractor.UpdateBond(address); // Create the bond object
 
         return true;
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -444,6 +444,9 @@ namespace hal
         auto gapAddress = services::GapAddress{ address, connectionContext.peerAddressType };
         if (!bondStorageInteractor.GetBond(gapAddress))
         {
+            if (bondStorageInteractor.Full())
+                bondStorageInteractor.RemoveLeastRecentlyUsedBond();
+
             auto newBond = services::Bond{ gapAddress, "" };
             bondStorageInteractor.AddBond(newBond);
         }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -102,6 +102,7 @@ namespace hal
     {
         AssertStateIs({ services::GapState::standby });
         bondStorageInteractor.RemoveAllBonds();
+        bondStorageInteractor.AssertBondStoragesAreInSync();
         UpdateNrBonds();
     }
 
@@ -452,6 +453,8 @@ namespace hal
         }
         else
             bondStorageInteractor.MarkAsRecentlyUsed(gapAddress);
+
+        bondStorageInteractor.AssertBondStoragesAreInSync();
 
         return true;
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -439,20 +439,19 @@ namespace hal
         if (!IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
             return false;
 
-        hal::MacAddress address = connectionContext.peerAddress;
-        aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), address.data());
+        services::GapAddress identityAddress{ connectionContext.peerAddress, connectionContext.peerAddressType };
+        aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), identityAddress.address.data());
 
-        auto gapAddress = services::GapAddress{ address, connectionContext.peerAddressType };
-        if (!bondStorageInteractor.GetBond(gapAddress))
+        if (!bondStorageInteractor.GetBond(identityAddress))
         {
             if (bondStorageInteractor.Full())
                 bondStorageInteractor.RemoveLeastRecentlyUsedBond();
 
-            auto newBond = services::Bond{ gapAddress, "" };
+            auto newBond = services::Bond{ identityAddress, "" };
             bondStorageInteractor.AddBond(newBond);
         }
         else
-            bondStorageInteractor.MarkAsRecentlyUsed(gapAddress);
+            bondStorageInteractor.MarkAsRecentlyUsed(identityAddress);
 
         bondStorageInteractor.AssertBondStoragesAreInSync();
 

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -115,12 +115,7 @@ namespace hal
 
     std::size_t GapSt::GetNumberOfBonds() const
     {
-        uint8_t numberOfBondedAddress = 0;
-        std::array<Bonded_Device_Entry_t, maxNumberOfBonds> bondedDevices;
-
-        aci_gap_get_bonded_devices(&numberOfBondedAddress, bondedDevices.data());
-
-        return numberOfBondedAddress;
+        return bondStorageInteractor.GetNumberOfBonds();
     }
 
     bool GapSt::IsDeviceBonded(MacAddress address, services::GapDeviceAddressType addressType) const
@@ -186,7 +181,7 @@ namespace hal
                 status = aci_gap_set_io_capability(4);
                 break;
             default:
-                std::abort();
+                LOG_AND_ABORT_ENUM(caps);
                 break;
         }
 
@@ -195,12 +190,12 @@ namespace hal
 
     void GapSt::AuthenticateWithPasskey(uint32_t passkey)
     {
-        std::abort();
+        LOG_AND_ABORT_NOT_IMPLEMENTED();
     }
 
     void GapSt::NumericComparisonConfirm(bool accept)
     {
-        std::abort();
+        LOG_AND_ABORT_NOT_IMPLEMENTED();
     }
 
     void GapSt::GenerateOutOfBandData()
@@ -436,7 +431,15 @@ namespace hal
 
         hal::MacAddress address = connectionContext.peerAddress;
         aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), address.data());
-        // bondStorageInteractor.UpdateBond(address); // Create the bond object
+
+        auto gapAddress = services::GapAddress{ address, connectionContext.peerAddressType };
+        if (!bondStorageInteractor.GetBond(gapAddress))
+        {
+            auto newBond = services::Bond{ gapAddress, "" };
+            bondStorageInteractor.AddBond(newBond);
+        }
+        else
+            bondStorageInteractor.MarkAsRecentlyUsed(gapAddress);
 
         return true;
     }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -451,6 +451,8 @@ namespace hal
                 bondStorageInteractor.RemoveBond(leastRecentlyUsedBond->address);
             }
 
+            // Note: The peerIdentityAddress might be of the wrong type.
+            // This is not an issue right now, because it's not stored in the bond storage
             auto newBond = services::Bond{ peerIdentityAddress, "" };
             bondStorageInteractor.AddBond(newBond);
         }

--- a/hal_st/middlewares/ble_middleware/GapSt.cpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.cpp
@@ -439,19 +439,23 @@ namespace hal
         if (!IsDeviceBonded(connectionContext.peerAddress, connectionContext.peerAddressType))
             return false;
 
-        services::GapAddress identityAddress{ connectionContext.peerAddress, connectionContext.peerAddressType };
-        aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), identityAddress.address.data());
+        services::GapAddress peerIdentityAddress{ connectionContext.peerAddress, connectionContext.peerAddressType };
+        aci_gap_resolve_private_addr(connectionContext.peerAddress.data(), peerIdentityAddress.address.data());
 
-        if (!bondStorageInteractor.GetBond(identityAddress))
+        if (!bondStorageInteractor.GetBond(peerIdentityAddress))
         {
             if (bondStorageInteractor.Full())
-                bondStorageInteractor.RemoveLeastRecentlyUsedBond();
+            {
+                auto leastRecentlyUsedBond = bondStorageInteractor.GetLeastRecentlyUsedBond();
+                really_assert(leastRecentlyUsedBond.has_value());
+                bondStorageInteractor.RemoveBond(leastRecentlyUsedBond->address);
+            }
 
-            auto newBond = services::Bond{ identityAddress, "" };
+            auto newBond = services::Bond{ peerIdentityAddress, "" };
             bondStorageInteractor.AddBond(newBond);
         }
         else
-            bondStorageInteractor.MarkAsRecentlyUsed(identityAddress);
+            bondStorageInteractor.MarkAsRecentlyUsed(peerIdentityAddress);
 
         bondStorageInteractor.AssertBondStoragesAreInSync();
 

--- a/hal_st/middlewares/ble_middleware/GapSt.hpp
+++ b/hal_st/middlewares/ble_middleware/GapSt.hpp
@@ -5,7 +5,7 @@
 #include "ble_defs.h"
 #include "hal_st/middlewares/ble_middleware/HciEventObserver.hpp"
 #include "infra/util/BoundedString.hpp"
-#include "services/ble/BondStorageSynchronizer.hpp"
+#include "services/ble/BondStorageInteractor.hpp"
 #include "services/ble/Gap.hpp"
 #include "services/ble/Gatt.hpp"
 
@@ -43,6 +43,7 @@ namespace hal
 
         struct Configuration
         {
+            services::BondStorageInteractor& bondStorageInteractor;
             const MacAddress& address;
             const GapService& gapService;
             const RootKeys& rootKeys;
@@ -77,7 +78,7 @@ namespace hal
             mandatory
         };
 
-        GapSt(HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration);
+        GapSt(HciEventSource& hciEventSource, const Configuration& configuration);
 
         virtual void HandleHciDisconnectEvent(const hci_disconnection_complete_event_rp0& event);
 
@@ -142,7 +143,7 @@ namespace hal
         static constexpr uint8_t maxNumberOfBonds = 10;
 
     private:
-        services::BondStorageSynchronizer& bondStorageSynchronizer;
+        services::BondStorageInteractor& bondStorageInteractor;
         RootKeys rootKeys;
         MacAddress publicAddress;
         uint8_t txPowerLevel;

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.cpp
@@ -2,8 +2,8 @@
 
 namespace hal
 {
-    TracingGapCentralSt::TracingGapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration, services::Tracer& tracer)
-        : GapCentralSt(hciEventSource, bondStorageSynchronizer, configuration)
+    TracingGapCentralSt::TracingGapCentralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration, services::Tracer& tracer)
+        : GapCentralSt(hciEventSource, configuration)
         , tracer(tracer)
     {}
 

--- a/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapCentralSt.hpp
@@ -10,7 +10,7 @@ namespace hal
         : public GapCentralSt
     {
     public:
-        TracingGapCentralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration, services::Tracer& tracer);
+        TracingGapCentralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration, services::Tracer& tracer);
 
         // Implementation of services::GapCentral
         void Connect(hal::MacAddress macAddress, services::GapDeviceAddressType addressType, infra::Duration initiatingTimeout) override;

--- a/hal_st/middlewares/ble_middleware/TracingGapPeripheralSt.cpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapPeripheralSt.cpp
@@ -4,8 +4,8 @@
 
 namespace hal
 {
-    TracingGapPeripheralSt::TracingGapPeripheralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration, services::Tracer& tracer)
-        : GapPeripheralSt(hciEventSource, bondStorageSynchronizer, configuration)
+    TracingGapPeripheralSt::TracingGapPeripheralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration, services::Tracer& tracer)
+        : GapPeripheralSt(hciEventSource, configuration)
         , tracer(tracer)
     {}
 

--- a/hal_st/middlewares/ble_middleware/TracingGapPeripheralSt.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingGapPeripheralSt.hpp
@@ -10,7 +10,7 @@ namespace hal
         : public GapPeripheralSt
     {
     public:
-        TracingGapPeripheralSt(hal::HciEventSource& hciEventSource, services::BondStorageSynchronizer& bondStorageSynchronizer, const Configuration& configuration, services::Tracer& tracer);
+        TracingGapPeripheralSt(hal::HciEventSource& hciEventSource, const Configuration& configuration, services::Tracer& tracer);
 
         // Implementation of GapPeripheralSt
         void Advertise(services::GapAdvertisementType type, AdvertisementIntervalMultiplier multiplier) override;

--- a/hal_st/middlewares/ble_middleware/TracingSystemTransportLayerWb.hpp
+++ b/hal_st/middlewares/ble_middleware/TracingSystemTransportLayerWb.hpp
@@ -10,7 +10,12 @@ namespace hal
         : public SystemTransportLayerWb
     {
     public:
-        TracingSystemTransportLayerWb(services::ConfigurationStoreAccess<infra::ByteRange> flashStorage, BondStorageSynchronizerCreator& bondStorageSynchronizerCreator, Configuration configuration, const infra::Function<void(services::BondStorageSynchronizer&)>& onInitialized, services::Tracer& tracer);
+        TracingSystemTransportLayerWb(
+            services::ConfigurationStoreAccess<infra::ByteRange> flashStorage,
+            BondStorageSynchronizerCreator& bondStorageSynchronizerCreator,
+            Configuration configuration,
+            const infra::Function<void(services::BondStorageSynchronizer&)>& onInitialized,
+            services::Tracer& tracer);
 
     protected:
         void UserEventHandler(void* pPayload) override;


### PR DESCRIPTION
Changes GapST to use the new `BondStorageInteractor`. 
- There's a limitation in `BondStorageTi` where bond roles are not fully supported.. This is because of limitations in our upstream implemention.

Depends on:
- https://github.com/philips-software/amp-embedded-infra-lib/pull/1313

Related to:
- https://github.com/philips-internal/amp-hal-ti/pull/295